### PR TITLE
Disable the OCP RAG

### DIFF
--- a/internal/controller/funcs.go
+++ b/internal/controller/funcs.go
@@ -171,6 +171,14 @@ func PatchOLSConfig(
 		return err
 	}
 
+	// Disable the OCP RAG
+	// TODO(lucasagomes): Remove this once we have a "query router" that can
+	// handle multiple RAGs nicely
+	err = uns.SetNestedField(olsConfig.Object, true, "spec", "ols", "byokRAGOnly")
+	if err != nil {
+		return err
+	}
+
 	// Add info which OpenStackLightspeed instance owns the OLSConfig
 	labels := olsConfig.GetLabels()
 	updatedLabels := map[string]interface{}{


### PR DESCRIPTION
This patch sets the ByokRAGOnly option to true, this disables the default OCP RAG and was introduced by https://github.com/openshift/lightspeed-operator/pull/1009