### PR TITLE
Fix metric service name

### DIFF
--- a/config/default/metrics_service.yaml
+++ b/config/default/metrics_service.yaml
@@ -5,7 +5,7 @@ metadata:
     control-plane: controller-manager
     app.kubernetes.io/name: openstack-lightspeed-operator
     app.kubernetes.io/managed-by: kustomize
-  name: controller-manager-metrics-service
+  name: metrics
   namespace: system
 spec:
   ports:


### PR DESCRIPTION
The Service
"openstack-lightspeed-operator-controller-manager-metrics-service" is invalid: metadata.name: Invalid value:
"openstack-lightspeed-operator-controller-manager-metrics-service": must be no more than 63 characters