### PR TITLE
Expose maxTokenForResponse

### DIFF
--- a/api/v1beta1/openstacklightspeed_types.go
+++ b/api/v1beta1/openstacklightspeed_types.go
@@ -27,6 +27,7 @@ const (
 
 	// OpenStackLightspeedContainerImage is the fall-back container image for OpenStackLightspeed
 	OpenStackLightspeedContainerImage = "quay.io/openstack-lightspeed/rag-content:os-docs-2024.2"
+	MaxTokensForResponseDefault       = 2048
 )
 
 // OpenStackLightspeedSpec defines the desired state of OpenStackLightspeed
@@ -62,6 +63,10 @@ type OpenStackLightspeedCore struct {
 	// +kubebuilder:validation:Optional
 	// Configmap name containing a CA Certificates bundle
 	TLSCACertBundle string `json:"tlsCACertBundle"`
+
+	// +kubebuilder:validation:Optional
+	// MaxTokensForResponse defines the maximum number of tokens to be used for the response generation
+	MaxTokensForResponse int `json:"maxTokensForResponse,omitempty"`
 }
 
 // OpenStackLightspeedStatus defines the observed state of OpenStackLightspeed
@@ -104,7 +109,8 @@ func (instance OpenStackLightspeed) IsReady() bool {
 }
 
 type OpenStackLightspeedDefaults struct {
-	RAGImageURL string
+	RAGImageURL          string
+	MaxTokensForResponse int
 }
 
 var OpenStackLightspeedDefaultValues OpenStackLightspeedDefaults
@@ -115,6 +121,7 @@ func SetupDefaults() {
 	openStackLightspeedDefaults := OpenStackLightspeedDefaults{
 		RAGImageURL: util.GetEnvVar(
 			"RELATED_IMAGE_OPENSTACK_LIGHTSPEED_IMAGE_URL_DEFAULT", OpenStackLightspeedContainerImage),
+		MaxTokensForResponse: MaxTokensForResponseDefault,
 	}
 
 	OpenStackLightspeedDefaultValues = openStackLightspeedDefaults

--- a/config/crd/bases/lightspeed.openstack.org_openstacklightspeeds.yaml
+++ b/config/crd/bases/lightspeed.openstack.org_openstacklightspeeds.yaml
@@ -59,6 +59,10 @@ spec:
                 - rhelai_vllm
                 - fake_provider
                 type: string
+              maxTokensForResponse:
+                description: MaxTokensForResponse defines the maximum number of tokens
+                  to be used for the response generation
+                type: integer
               modelName:
                 description: Name of the model to use at the API endpoint provided
                   in LLMEndpoint

--- a/internal/controller/funcs.go
+++ b/internal/controller/funcs.go
@@ -126,8 +126,10 @@ func PatchOLSConfig(
 			},
 			"models": []interface{}{
 				map[string]interface{}{
-					"name":       instance.Spec.ModelName,
-					"parameters": map[string]interface{}{},
+					"name": instance.Spec.ModelName,
+					"parameters": map[string]interface{}{
+						"maxTokensForResponse": float64(instance.Spec.MaxTokensForResponse), // unstructured JSON numbers default to float64
+					},
 				},
 			},
 			"name": OpenStackLightspeedDefaultProvider,

--- a/internal/controller/openstacklightspeed_controller.go
+++ b/internal/controller/openstacklightspeed_controller.go
@@ -140,6 +140,10 @@ func (r *OpenStackLightspeedReconciler) Reconcile(ctx context.Context, req ctrl.
 		instance.Spec.RAGImage = apiv1beta1.OpenStackLightspeedDefaultValues.RAGImageURL
 	}
 
+	if instance.Spec.MaxTokensForResponse == 0 {
+		instance.Spec.MaxTokensForResponse = apiv1beta1.OpenStackLightspeedDefaultValues.MaxTokensForResponse
+	}
+
 	OLSOperatorInstalled, err := IsOLSOperatorInstalled(ctx, helper)
 	if !OLSOperatorInstalled || err != nil {
 		errMsg := fmt.Errorf("installation of OpenShift LightSpeed not detected")


### PR DESCRIPTION
This PR allows users to configure the maximum number of tokens for the response. It also sets the default to 2048 (double of the current default in OLS)