### PR TITLE
Change installation to openshift-lightspeed namespace

### DIFF
--- a/config/manifests/bases/openstack-lightspeed-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/openstack-lightspeed-operator.clusterserviceversion.yaml
@@ -4,8 +4,9 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
+    operatorframework.io/suggested-namespace: openshift-lightspeed
   name: openstack-lightspeed-operator.v0.0.0
-  namespace: placeholder
+  namespace: openshift-lightspeed
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions: {}
@@ -20,13 +21,13 @@ spec:
       deployments: null
     strategy: ""
   installModes:
-  - supported: false
+  - supported: true
     type: OwnNamespace
   - supported: false
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: true
+  - supported: false
     type: AllNamespaces
   keywords:
   - openstack


### PR DESCRIPTION
This patch changes the installation of the new operator to the openshift-lightspeed namespace instead of the "AllNamespaces".