### PR TITLE
Add Dependabot config for Go module updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+


### PR DESCRIPTION
Add .github/dependabot.yml to enable automatic dependency updates for Go modules.

Dependabot will check the go.mod file weekly and open PRs for new versions or security fixes.