### PR TITLE
Owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS SPEC docs:https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md#owners-spec
+
+approvers:
+  - core
+reviewers:
+  - core
+

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,7 @@
+# See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#owners_aliases
+
+aliases:
+  core:
+  - umago
+  - lpiwowar
+  - Akrog


### PR DESCRIPTION
"""Shortly following the merge of the onboarding PR, the periodic-prow-auto-owners job will sync the OWNERS file from the component repository to the relevant directories. Assumming this file exists in the repo’s base directory, this sync is performed periodically, and will sync all members in that file that are also members of the openshift GitHub org. This means that the component’s OWNERS file is the only one that needs to be manually updated. See #forum-pge-cloud-ops to gain membership in the openshift org"""

Ref: https://docs.ci.openshift.org/docs/how-tos/onboarding-a-new-component/#setting-up-team-ownership-of-ci-operator-and-prow-config-files