### PR TITLE
CI: Do not pin on GO 1.23 version

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -20,9 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.23'
+        uses: actions/setup-go@v6
 
       - name: Prepare variables
         id: vars

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -16,8 +16,6 @@ jobs:
 
     - name: Set up Go
       uses: actions/setup-go@v6
-      with:
-        go-version: '1.23'
 
     - name: Run pre-commit hooks
       uses: pre-commit/action@v3.0.1

--- a/.github/workflows/verify-generation.yaml
+++ b/.github/workflows/verify-generation.yaml
@@ -16,8 +16,6 @@ jobs:
 
     - name: Set up Go
       uses: actions/setup-go@v6
-      with:
-        go-version: '1.23'
 
     - name: Install operator-sdk
       uses: redhat-actions/openshift-tools-installer@v1


### PR DESCRIPTION
Dependabot is failing due to the mismatch versions of GO in the CI jobs.