### PR TITLE
Allow feedback/transcripts to be disabled

### DIFF
--- a/api/v1beta1/openstacklightspeed_types.go
+++ b/api/v1beta1/openstacklightspeed_types.go
@@ -89,6 +89,14 @@ type OpenStackLightspeedCore struct {
 	// +kubebuilder:validation:Optional
 	// LLM API Version for LLM providers that require it (e.g., Microsoft Azure OpenAI)
 	LLMAPIVersion string `json:"llmAPIVersion,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// Disable feedback collection
+	FeedbackDisabled bool `json:"feedbackDisabled,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// Disable conversation transcripts collection
+	TranscriptsDisabled bool `json:"transcriptsDisabled,omitempty"`
 }
 
 // OpenStackLightspeedStatus defines the observed state of OpenStackLightspeed

--- a/bundle/manifests/lightspeed.openstack.org_openstacklightspeeds.yaml
+++ b/bundle/manifests/lightspeed.openstack.org_openstacklightspeeds.yaml
@@ -58,6 +58,9 @@ spec:
                 description: Namespace where the CatalogSource containing the OLS
                   operator is located
                 type: string
+              feedbackDisabled:
+                description: Disable feedback collection
+                type: boolean
               llmAPIVersion:
                 description: LLM API Version for LLM providers that require it (e.g.,
                   Microsoft Azure OpenAI)
@@ -103,6 +106,9 @@ spec:
               tlsCACertBundle:
                 description: Configmap name containing a CA Certificates bundle
                 type: string
+              transcriptsDisabled:
+                description: Disable conversation transcripts collection
+                type: boolean
             required:
             - llmCredentials
             - llmEndpoint

--- a/bundle/manifests/openstack-lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/openstack-lightspeed-operator.clusterserviceversion.yaml
@@ -24,7 +24,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2026-01-08T13:07:00Z"
+    createdAt: "2026-01-16T13:55:22Z"
     operatorframework.io/suggested-namespace: openshift-lightspeed
     operators.operatorframework.io/builder: operator-sdk-v1.38.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/config/crd/bases/lightspeed.openstack.org_openstacklightspeeds.yaml
+++ b/config/crd/bases/lightspeed.openstack.org_openstacklightspeeds.yaml
@@ -58,6 +58,9 @@ spec:
                 description: Namespace where the CatalogSource containing the OLS
                   operator is located
                 type: string
+              feedbackDisabled:
+                description: Disable feedback collection
+                type: boolean
               llmAPIVersion:
                 description: LLM API Version for LLM providers that require it (e.g.,
                   Microsoft Azure OpenAI)
@@ -103,6 +106,9 @@ spec:
               tlsCACertBundle:
                 description: Configmap name containing a CA Certificates bundle
                 type: string
+              transcriptsDisabled:
+                description: Disable conversation transcripts collection
+                type: boolean
             required:
             - llmCredentials
             - llmEndpoint

--- a/internal/controller/funcs.go
+++ b/internal/controller/funcs.go
@@ -216,6 +216,18 @@ func PatchOLSConfig(
 		return err
 	}
 
+	// Disable or enable feedback collection
+	err = uns.SetNestedField(olsConfig.Object, instance.Spec.FeedbackDisabled, "spec", "ols", "userDataCollection", "feedbackDisabled")
+	if err != nil {
+		return err
+	}
+
+	// Disable or enable transcripts collection
+	err = uns.SetNestedField(olsConfig.Object, instance.Spec.TranscriptsDisabled, "spec", "ols", "userDataCollection", "transcriptsDisabled")
+	if err != nil {
+		return err
+	}
+
 	// Add info which OpenStackLightspeed instance owns the OLSConfig
 	labels := olsConfig.GetLabels()
 	updatedLabels := map[string]interface{}{

--- a/test/kuttl/common/openstack-lightspeed-instance/assert-openstack-lightspeed-instance.yaml
+++ b/test/kuttl/common/openstack-lightspeed-instance/assert-openstack-lightspeed-instance.yaml
@@ -29,6 +29,9 @@ spec:
       - image: quay.io/openstack-lightspeed/rag-content:os-docs-2025.2
         indexID: ""
         indexPath: /rag/vector_db/os_product_docs
+    userDataCollection:
+      feedbackDisabled: false
+      transcriptsDisabled: false
 status:
   conditions:
     - type: ConsolePluginReady

--- a/test/kuttl/tests/update-openstacklightspeed/04-update-openstack-lightspeed-instance.yaml
+++ b/test/kuttl/tests/update-openstacklightspeed/04-update-openstack-lightspeed-instance.yaml
@@ -13,3 +13,5 @@ spec:
   llmProjectID: test-project-id-UPDATE
   llmDeploymentName: test-deployment-name-UPDATE
   llmAPIVersion: v1.1
+  feedbackDisabled: true
+  transcriptsDisabled: true

--- a/test/kuttl/tests/update-openstacklightspeed/05-assert-olsconfig-update.yaml
+++ b/test/kuttl/tests/update-openstacklightspeed/05-assert-olsconfig-update.yaml
@@ -29,3 +29,6 @@ spec:
       - image: quay.io/openstack-lightspeed/rag-content:os-docs-2025.2
         indexID: ""
         indexPath: /rag/vector_db/os_product_docs
+    userDataCollection:
+      feedbackDisabled: true
+      transcriptsDisabled: true


### PR DESCRIPTION
This patch adds two new configuration options to OpenStack Lightspeed config:

* FeedbackDisabled: If set to true, disable feedback collection
* TranscriptsDisabled: If set to true, disable conversation transcripts collection