### PR TITLE
Add the disconnected annotation

### DIFF
--- a/bundle/manifests/openstack-lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/openstack-lightspeed-operator.clusterserviceversion.yaml
@@ -25,11 +25,12 @@ metadata:
       ]
     capabilities: Basic Install
     categories: AI/Machine Learning
-    createdAt: "2026-02-18T16:58:24Z"
+    createdAt: "2026-02-19T09:36:07Z"
     description: AI-powered virtual assistant for Red Hat OpenStack Services on OpenShift
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
+    features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "false"
     features.operators.openshift.io/proxy-aware: "false"
     features.operators.openshift.io/tls-profiles: "false"

--- a/config/manifests/bases/openstack-lightspeed-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/openstack-lightspeed-operator.clusterserviceversion.yaml
@@ -9,6 +9,7 @@ metadata:
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
+    features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "false"
     features.operators.openshift.io/proxy-aware: "false"
     features.operators.openshift.io/tls-profiles: "false"


### PR DESCRIPTION
The commit 0764340799d549a99f6d5b07d9287703c4e0dab9 added support for airgapped (disconnect) environments. This patch just adds the annotation indicates that the Operator works in a disconnected environment.

Operators such as the "openstack" one already uses this annotation [0] and it is suggested by [1] so it can be filtered in OperatorHub by this infrastructure feature.

[0] https://github.com/openstack-k8s-operators/openstack-operator/commit/6b99f5b46582206e3f72790c13e83088e7a26c27
[1] https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/operators/developing-operators