### PR TITLE
Enable image digests in bundle generation

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Generate bundle
         run: |
-          make bundle IMG=$OPERATOR_IMAGE
+          make bundle IMG=$OPERATOR_IMAGE USE_IMAGE_DIGESTS=true
           make bundle-build BUNDLE_IMG=$BUNDLE_IMAGE
           docker tag $BUNDLE_IMAGE $BUNDLE_IMAGE_LATEST
           make bundle-push BUNDLE_IMG=$BUNDLE_IMAGE


### PR DESCRIPTION
Set USE_IMAGE_DIGESTS=true when running make bundle to pin images using SHA256 digests. This improves security and reproducibility, and simplifies releases to the community-operators catalog (we can just extract the content of the bundle image, make minor modifications and we are ready for the release).