### PR TITLE
Fix the OCP directory to use _ instead of -

### DIFF
--- a/internal/controller/ocp_version.go
+++ b/internal/controller/ocp_version.go
@@ -113,11 +113,11 @@ func GetOCPIndexName(version string) string {
 }
 
 // GetOCPVectorDBPath returns the full path to OCP vector DB for given version
-// Example: "4.16" -> "/rag/ocp_vector_db/ocp-4.16"
+// Example: "4.16" -> "/rag/ocp_vector_db/ocp_4.16"
 //
-//	"latest" -> "/rag/ocp_vector_db/ocp-latest"
+//	"latest" -> "/rag/ocp_vector_db/ocp_latest"
 func GetOCPVectorDBPath(version string) string {
-	return fmt.Sprintf("%s-%s", OpenStackLightspeedOCPVectorDBPath, version)
+	return fmt.Sprintf("%s_%s", OpenStackLightspeedOCPVectorDBPath, version)
 }
 
 // IsSupportedOCPVersion checks if the version is explicitly supported in RAG DB

--- a/internal/controller/ocp_version_test.go
+++ b/internal/controller/ocp_version_test.go
@@ -69,17 +69,17 @@ func TestGetOCPVectorDBPath(t *testing.T) {
 		{
 			name:     "Version 4.16",
 			version:  "4.16",
-			expected: "/rag/ocp_vector_db/ocp-4.16",
+			expected: "/rag/ocp_vector_db/ocp_4.16",
 		},
 		{
 			name:     "Version 4.18",
 			version:  "4.18",
-			expected: "/rag/ocp_vector_db/ocp-4.18",
+			expected: "/rag/ocp_vector_db/ocp_4.18",
 		},
 		{
 			name:     "Latest version",
 			version:  "latest",
-			expected: "/rag/ocp_vector_db/ocp-latest",
+			expected: "/rag/ocp_vector_db/ocp_latest",
 		},
 	}
 
@@ -313,8 +313,8 @@ func TestBuildRAGConfigs(t *testing.T) {
 		if !ok {
 			t.Fatalf("Expected indexPath to be string, got %T", ocpConfig["indexPath"])
 		}
-		if ocpPath != "/rag/ocp_vector_db/ocp-4.16" {
-			t.Errorf("OCP indexPath = %s, want /rag/ocp_vector_db/ocp-4.16", ocpPath)
+		if ocpPath != "/rag/ocp_vector_db/ocp_4.16" {
+			t.Errorf("OCP indexPath = %s, want /rag/ocp_vector_db/ocp_4.16", ocpPath)
 		}
 
 		ocpIndexID, ok := ocpConfig["indexID"].(string)
@@ -354,8 +354,8 @@ func TestBuildRAGConfigs(t *testing.T) {
 		if !ok {
 			t.Fatalf("Expected indexPath to be string, got %T", ocpConfig["indexPath"])
 		}
-		if ocpPath != "/rag/ocp_vector_db/ocp-latest" {
-			t.Errorf("OCP indexPath = %s, want /rag/ocp_vector_db/ocp-latest", ocpPath)
+		if ocpPath != "/rag/ocp_vector_db/ocp_latest" {
+			t.Errorf("OCP indexPath = %s, want /rag/ocp_vector_db/ocp_latest", ocpPath)
 		}
 
 		ocpIndexID, ok := ocpConfig["indexID"].(string)

--- a/test/kuttl/tests/update-openstacklightspeed/05-assert-olsconfig-update.yaml
+++ b/test/kuttl/tests/update-openstacklightspeed/05-assert-olsconfig-update.yaml
@@ -31,7 +31,7 @@ spec:
         indexPath: /rag/vector_db/os_product_docs
       - image: quay.io/openstack-lightspeed/rag-content:os-docs-2025.2
         indexID: ocp-product-docs-4_16
-        indexPath: /rag/ocp_vector_db/ocp-4.16
+        indexPath: /rag/ocp_vector_db/ocp_4.16
     userDataCollection:
       feedbackDisabled: true
       transcriptsDisabled: true


### PR DESCRIPTION
With the current operator code we configure OLS with the wrong path for the OCP RAG when enabled.

It's a tiny issue where we are creating the directory name using `-` instead of `_`.