### PR TITLE
Add CSV spec descriptors

### DIFF
--- a/api/v1beta1/openstacklightspeed_types.go
+++ b/api/v1beta1/openstacklightspeed_types.go
@@ -52,6 +52,7 @@ type OpenStackLightspeedSpec struct {
 // OpenStackLightspeedCore defines the desired state of OpenStackLightspeed
 type OpenStackLightspeedCore struct {
 	// +kubebuilder:validation:Required
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="LLM Endpoint"
 	// URL pointing to the LLM
 	LLMEndpoint string `json:"llmEndpoint"`
 
@@ -62,15 +63,18 @@ type OpenStackLightspeedCore struct {
 	LLMEndpointType string `json:"llmEndpointType"`
 
 	// +kubebuilder:validation:Required
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Model Name"
 	// Name of the model to use at the API endpoint provided in LLMEndpoint
 	ModelName string `json:"modelName"`
 
 	// +kubebuilder:validation:Required
-	// Secret name containing API token for the LLMEndpoint. The key for the field
-	// in the secret that holds the token should be "apitoken".
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="LLM Credentials Secret"
+	// Secret name containing API token for the LLMEndpoint. The secret must contain
+	// a field named "apitoken" which holds the token value.
 	LLMCredentials string `json:"llmCredentials"`
 
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="TLS CA Certificate Bundle"
 	// Configmap name containing a CA Certificates bundle
 	TLSCACertBundle string `json:"tlsCACertBundle"`
 

--- a/bundle/manifests/lightspeed.openstack.org_openstacklightspeeds.yaml
+++ b/bundle/manifests/lightspeed.openstack.org_openstacklightspeeds.yaml
@@ -72,8 +72,8 @@ spec:
                 type: string
               llmCredentials:
                 description: |-
-                  Secret name containing API token for the LLMEndpoint. The key for the field
-                  in the secret that holds the token should be "apitoken".
+                  Secret name containing API token for the LLMEndpoint. The secret must contain
+                  a field named "apitoken" which holds the token value.
                 type: string
               llmDeploymentName:
                 description: Deployment name for LLM providers that require it (e.g.,

--- a/bundle/manifests/openstack-lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/openstack-lightspeed-operator.clusterserviceversion.yaml
@@ -25,7 +25,7 @@ metadata:
       ]
     capabilities: Basic Install
     categories: AI/Machine Learning
-    createdAt: "2026-02-19T12:53:35Z"
+    createdAt: "2026-02-19T13:45:56Z"
     description: AI-powered virtual assistant for Red Hat OpenStack Services on OpenShift
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
@@ -66,9 +66,23 @@ spec:
         name: cluster
         version: v1alpha1
       specDescriptors:
+      - description: |-
+          Secret name containing API token for the LLMEndpoint. The secret must contain
+          a field named "apitoken" which holds the token value.
+        displayName: LLM Credentials Secret
+        path: llmCredentials
+      - description: URL pointing to the LLM
+        displayName: LLM Endpoint
+        path: llmEndpoint
       - description: Type of the provider serving the LLM
         displayName: Provider Type
         path: llmEndpointType
+      - description: Name of the model to use at the API endpoint provided in LLMEndpoint
+        displayName: Model Name
+        path: modelName
+      - description: Configmap name containing a CA Certificates bundle
+        displayName: TLS CA Certificate Bundle
+        path: tlsCACertBundle
       version: v1beta1
   description: |-
     OpenStack Lightspeed is a generative AI-based virtual assistant for Red Hat OpenStack Services on OpenShift (RHOSO) users which integrates into the OpenShift Lightspeed.

--- a/config/crd/bases/lightspeed.openstack.org_openstacklightspeeds.yaml
+++ b/config/crd/bases/lightspeed.openstack.org_openstacklightspeeds.yaml
@@ -72,8 +72,8 @@ spec:
                 type: string
               llmCredentials:
                 description: |-
-                  Secret name containing API token for the LLMEndpoint. The key for the field
-                  in the secret that holds the token should be "apitoken".
+                  Secret name containing API token for the LLMEndpoint. The secret must contain
+                  a field named "apitoken" which holds the token value.
                 type: string
               llmDeploymentName:
                 description: Deployment name for LLM providers that require it (e.g.,

--- a/config/manifests/bases/openstack-lightspeed-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/openstack-lightspeed-operator.clusterserviceversion.yaml
@@ -43,9 +43,23 @@ spec:
         name: cluster
         version: v1alpha1
       specDescriptors:
+      - description: |-
+          Secret name containing API token for the LLMEndpoint. The secret must contain
+          a field named "apitoken" which holds the token value.
+        displayName: LLM Credentials Secret
+        path: llmCredentials
+      - description: URL pointing to the LLM
+        displayName: LLM Endpoint
+        path: llmEndpoint
       - description: Type of the provider serving the LLM
         displayName: Provider Type
         path: llmEndpointType
+      - description: Name of the model to use at the API endpoint provided in LLMEndpoint
+        displayName: Model Name
+        path: modelName
+      - description: Configmap name containing a CA Certificates bundle
+        displayName: TLS CA Certificate Bundle
+        path: tlsCACertBundle
       version: v1beta1
   description: |-
     OpenStack Lightspeed is a generative AI-based virtual assistant for Red Hat OpenStack Services on OpenShift (RHOSO) users which integrates into the OpenShift Lightspeed.


### PR DESCRIPTION
Add operator-sdk CSV annotations to OpenStackLightspeed spec fields to generate proper spec descriptors in the ClusterServiceVersion manifests. This ensures the operator passes scorecard tests [1] (olm-spec-descriptors-test test).

[1] https://sdk.operatorframework.io/docs/testing-operators/scorecard/

### Before the fix

```
$ operator-sdk scorecard ./bundle
...
--------------------------------------------------------------------------------
Image:      quay.io/operator-framework/scorecard-test:v1.38.0
Entrypoint: [scorecard-test olm-spec-descriptors]
Labels:
	"suite":"olm"
	"test":"olm-spec-descriptors-test"
Results:
	Name: olm-spec-descriptors
	State: fail

	Suggestions:
		Add a spec descriptor for llmCredentials
		Add a spec descriptor for llmEndpoint
		Add a spec descriptor for modelName
		Add a spec descriptor for tlsCACertBundle
	Errors:
		llmCredentials does not have a spec descriptor
		llmEndpoint does not have a spec descriptor
		modelName does not have a spec descriptor
		tlsCACertBundle does not have a spec descriptor
	Log:
		Loaded ClusterServiceVersion: openstack-lightspeed-operator.v0.0.1
		Loaded 1 Custom Resources from alm-examples
...
```

### Note

It is recommended to run these tests as part of the community-operators pipeline. If we do not fix this then these tests will fail.