### PR TITLE
Add resources to CSV

### DIFF
--- a/api/v1beta1/openstacklightspeed_types.go
+++ b/api/v1beta1/openstacklightspeed_types.go
@@ -127,6 +127,10 @@ type OpenStackLightspeedStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[0].status",description="Status"
 // +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[0].message",description="Message"
+// +operator-sdk:csv:customresourcedefinitions:resources={{OLSConfig,v1alpha1,cluster}}
+// +operator-sdk:csv:customresourcedefinitions:resources={{Subscription,v1alpha1}}
+// +operator-sdk:csv:customresourcedefinitions:resources={{ClusterServiceVersion,v1alpha1}}
+// +operator-sdk:csv:customresourcedefinitions:resources={{InstallPlan,v1alpha}}
 
 // OpenStackLightspeed is the Schema for the openstacklightspeeds API
 type OpenStackLightspeed struct {

--- a/bundle/manifests/openstack-lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/openstack-lightspeed-operator.clusterserviceversion.yaml
@@ -25,7 +25,7 @@ metadata:
       ]
     capabilities: Basic Install
     categories: AI/Machine Learning
-    createdAt: "2026-02-19T09:36:07Z"
+    createdAt: "2026-02-19T12:53:35Z"
     description: AI-powered virtual assistant for Red Hat OpenStack Services on OpenShift
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
@@ -52,6 +52,19 @@ spec:
       displayName: Open Stack Lightspeed
       kind: OpenStackLightspeed
       name: openstacklightspeeds.lightspeed.openstack.org
+      resources:
+      - kind: ClusterServiceVersion
+        name: ""
+        version: v1alpha1
+      - kind: InstallPlan
+        name: ""
+        version: v1alpha
+      - kind: Subscription
+        name: ""
+        version: v1alpha1
+      - kind: OLSConfig
+        name: cluster
+        version: v1alpha1
       specDescriptors:
       - description: Type of the provider serving the LLM
         displayName: Provider Type

--- a/config/manifests/bases/openstack-lightspeed-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/openstack-lightspeed-operator.clusterserviceversion.yaml
@@ -29,6 +29,19 @@ spec:
       displayName: Open Stack Lightspeed
       kind: OpenStackLightspeed
       name: openstacklightspeeds.lightspeed.openstack.org
+      resources:
+      - kind: ClusterServiceVersion
+        name: ""
+        version: v1alpha1
+      - kind: InstallPlan
+        name: ""
+        version: v1alpha
+      - kind: Subscription
+        name: ""
+        version: v1alpha1
+      - kind: OLSConfig
+        name: cluster
+        version: v1alpha1
       specDescriptors:
       - description: Type of the provider serving the LLM
         displayName: Provider Type


### PR DESCRIPTION
Add resources section to ClusterServiceVersion describing the resources managed by the OpenStackLightspeed CR. This fixes the olm-crds-have-resources-test scorecard check [1].

[1] https://sdk.operatorframework.io/docs/testing-operators/scorecard/

### Before the fix

```
$ operator-sdk scorecard ./bundle
...
--------------------------------------------------------------------------------
Image:      quay.io/operator-framework/scorecard-test:v1.38.0
Entrypoint: [scorecard-test olm-crds-have-resources]
Labels:
	"suite":"olm"
	"test":"olm-crds-have-resources-test"
Results:
	Name: olm-crds-have-resources
	State: fail

	Errors:
		Owned CRDs do not have resources specified
	Log:
		Loaded ClusterServiceVersion: openstack-lightspeed-operator.v0.0.1
...
```

### Note 

It is recommended to run these tests as part of the community-operators pipeline. If we do not fix this then these tests will fail.