### PR TITLE
Enforce the minimum TLS version to 1.3

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -90,14 +90,14 @@ func main() {
 	// Rapid Reset CVEs. For more information see:
 	// - https://github.com/advisories/GHSA-qppj-fm5r-hxr3
 	// - https://github.com/advisories/GHSA-4374-p667-p6c8
-	disableHTTP2 := func(c *tls.Config) {
-		setupLog.Info("disabling http/2")
-		c.NextProtos = []string{"http/1.1"}
-	}
-
-	if !enableHTTP2 {
-		tlsOpts = append(tlsOpts, disableHTTP2)
-	}
+	tlsOpts = append(tlsOpts, func(c *tls.Config) {
+		setupLog.Info("enforcing minimum TLS version 1.3")
+		c.MinVersion = tls.VersionTLS13
+		if !enableHTTP2 {
+			setupLog.Info("disabling http/2")
+			c.NextProtos = []string{"http/1.1"}
+		}
+	})
 
 	webhookServer := webhook.NewServer(webhook.Options{
 		TLSOpts: tlsOpts,


### PR DESCRIPTION
Based on the QPC analysis tool we should enforce the minimum version of TLS to 1.3 as older TLS versions are vulnerable to quantum attacks.