### PR TITLE
Add valid-subscription annotation to CSV

### DIFF
--- a/bundle/manifests/openstack-lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/openstack-lightspeed-operator.clusterserviceversion.yaml
@@ -25,7 +25,7 @@ metadata:
       ]
     capabilities: Basic Install
     categories: AI/Machine Learning
-    createdAt: "2026-02-19T13:45:56Z"
+    createdAt: "2026-04-15T07:57:01Z"
     description: AI-powered virtual assistant for Red Hat OpenStack Services on OpenShift
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
@@ -38,6 +38,8 @@ metadata:
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
     operatorframework.io/suggested-namespace: openshift-lightspeed
+    operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift
+      Platform Plus"]'
     operators.operatorframework.io/builder: operator-sdk-v1.38.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/openstack-lightspeed/operator

--- a/config/manifests/bases/openstack-lightspeed-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/openstack-lightspeed-operator.clusterserviceversion.yaml
@@ -17,6 +17,8 @@ metadata:
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
     operatorframework.io/suggested-namespace: openshift-lightspeed
+    operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift
+      Platform Plus"]'
     repository: https://github.com/openstack-lightspeed/operator
   name: openstack-lightspeed-operator.v0.0.0
   namespace: openshift-lightspeed


### PR DESCRIPTION
This annotation is optional in the operator spec [1] but actually required to release the operator downstream.

It lists subscriptions required to use the operator. Let's use the same value as openstack-operator [2].

[RELDEL-8649](https://redhat.atlassian.net/browse/RELDEL-8649)

[1] https://docs.okd.io/4.18/operators/operator_sdk/osdk-generating-csvs.html#osdk-csv-annotations-other_osdk-generating-csvs
[2] https://github.com/openstack-k8s-operators/openstack-operator/blob/b950208d215e81f0cc2e0a9e6f6857a491d7f0c8/config/operator/manifests/bases/openstack-operator.clusterserviceversion.yaml#L14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated operator metadata annotations to specify valid OpenShift subscriptions: OpenShift Container Platform and OpenShift Platform Plus.
  * Updated operator metadata timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->