### PR TITLE
Add registry.redhat.io login to GH workflow

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -68,6 +68,13 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
 
+      - name: Log in to Red Hat Registry
+        uses: docker/login-action@v4
+        with:
+          registry: registry.redhat.io
+          username: ${{ secrets.REDHAT_REGISTRY_USERNAME }}
+          password: ${{ secrets.REDHAT_REGISTRY_PASSWORD }}
+
       - name: Build operator image
         run: |
           make docker-build IMG=$OPERATOR_IMAGE

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -62,7 +62,7 @@ jobs:
           operator-sdk: 1.38.0
 
       - name: Log in to Quay
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}


### PR DESCRIPTION
The bundle generation step resolves image tags to digests, which requires pulling from registry.redhat.io (for the PostgreSQL image). Add authentication so the CI runner can access the Red Hat registry.

This PR resolves [this GitHub workflow error](https://github.com/openstack-lightspeed/operator/actions/runs/24500959142) we hit after merging the initial PR for the `lcore` migration.