### PR TITLE
Add shellcheck and ruff pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,13 @@ repos:
         entry: make
         args: ['lint']
         pass_filenames: false
+      - id: shellcheck
+        name: shellcheck
+        language: system
+        entry: shellcheck
+        types: [shell]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.13
+    hooks:
+      - id: ruff
+      - id: ruff-format

--- a/hack/pullspecs_replaceatron.sh
+++ b/hack/pullspecs_replaceatron.sh
@@ -37,7 +37,9 @@ for var_name in $RELATED_IMAGE_VARS; do
 
         if [[ -n "$current_csv_value" ]]; then
             # Escape special characters for sed
+            # shellcheck disable=SC2016
             escaped_current=$(printf '%s\n' "$current_csv_value" | sed 's/[[\.*^$()+?{|]/\\&/g')
+            # shellcheck disable=SC2016
             escaped_new=$(printf '%s\n' "$current_value" | sed 's/[[\.*^$()+?{|]/\\&/g')
 
             # Replace all occurrences of the current value with the new value

--- a/internal/controller/assets/postgres_bootstrap.sh
+++ b/internal/controller/assets/postgres_bootstrap.sh
@@ -11,15 +11,15 @@ _psql () { psql --set ON_ERROR_STOP=1 "$@" ; }
 # Create database for llama-stack conversation storage
 DB_NAME="llamastack"
 
-echo "SELECT 'CREATE DATABASE $DB_NAME' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = '$DB_NAME')\gexec" | _psql -d $POSTGRESQL_DATABASE
+echo "SELECT 'CREATE DATABASE $DB_NAME' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = '$DB_NAME')\gexec" | _psql -d "$POSTGRESQL_DATABASE"
 
 # Create pg_trgm extension in default database (for OpenStack Lightspeed conversation cache)
-echo "CREATE EXTENSION IF NOT EXISTS pg_trgm;" | _psql -d $POSTGRESQL_DATABASE
+echo "CREATE EXTENSION IF NOT EXISTS pg_trgm;" | _psql -d "$POSTGRESQL_DATABASE"
 
 # Create pg_trgm extension in llama-stack database (for text search if needed)
 echo "CREATE EXTENSION IF NOT EXISTS pg_trgm;" | _psql -d $DB_NAME
 
 # Create schemas for isolating different components' data
-echo "CREATE SCHEMA IF NOT EXISTS lcore;" | _psql -d $POSTGRESQL_DATABASE
-echo "CREATE SCHEMA IF NOT EXISTS quota;" | _psql -d $POSTGRESQL_DATABASE
-echo "CREATE SCHEMA IF NOT EXISTS conversation_cache;" | _psql -d $POSTGRESQL_DATABASE
+echo "CREATE SCHEMA IF NOT EXISTS lcore;" | _psql -d "$POSTGRESQL_DATABASE"
+echo "CREATE SCHEMA IF NOT EXISTS quota;" | _psql -d "$POSTGRESQL_DATABASE"
+echo "CREATE SCHEMA IF NOT EXISTS conversation_cache;" | _psql -d "$POSTGRESQL_DATABASE"

--- a/internal/controller/assets/vector_database_collect.sh
+++ b/internal/controller/assets/vector_database_collect.sh
@@ -56,7 +56,7 @@
 #  --enable-ocp-rag BOOL    Enable OCP vector DB collection: true/false (required)
 #  --ocp-version VERSION    OCP version to collect, e.g., "X.YZ" (required)
 
-set -euo pipefail
+set -eu
 
 # -- vector_database_collect.sh script parameters ----------------------------
 
@@ -173,7 +173,7 @@ parse_arguments_and_init() {
 }
 
 validate_vector_db_dir() {
-    local vector_db_dir="$1"
+    vector_db_dir="$1"
 
     if [ ! -d "${vector_db_dir}" ]; then
         echo "ERROR: ${vector_db_dir} is not a directory"
@@ -200,7 +200,7 @@ collect_ocp_vector_db_data() {
     echo "Collecting OCP vector DB data ..."
     mkdir -p "${VECTOR_DB_DATA_COLLECT_DIR}"
 
-    local ocp_dir="${OCP_VECTOR_DB_DIR}/ocp_${OCP_VERSION}"
+    ocp_dir="${OCP_VECTOR_DB_DIR}/ocp_${OCP_VERSION}"
     if [ ! -d "${ocp_dir}" ]; then
         echo "Data for OCP version ${OCP_VERSION} not found. Using: ${OCP_VECTOR_DB_DIR_FALLBACK}"
         ocp_dir=${OCP_VECTOR_DB_DIR_FALLBACK}
@@ -214,8 +214,8 @@ collect_ocp_vector_db_data() {
 collect_vector_db_data() {
     echo "Collecting vector DB data ..."
     mkdir -p "${VECTOR_DB_DATA_COLLECT_DIR}"
-    local vector_db_data_collected="false"
-    for dir in ${VECTOR_DB_DIR}/*/; do
+    vector_db_data_collected="false"
+    for dir in "${VECTOR_DB_DIR}"/*/; do
         [ ! -d "$dir" ] && continue
 
         validate_vector_db_dir "$dir"

--- a/scripts/gen-rhosls.sh
+++ b/scripts/gen-rhosls.sh
@@ -32,7 +32,7 @@ spec:
   - openstack-lightspeed
 EOF
 
-for i in $(seq 1 20); do
+for _i in $(seq 1 20); do
   CSV_VERSION=$(oc get --ignore-not-found=true packagemanifest openstack-lightspeed-operator -o go-template="{{range .status.channels}}{{if eq .name \"${CHANNEL}\"}}{{.currentCSV}}{{\"\n\"}}{{end}}{{end}}")
   if [ -n "${CSV_VERSION}" ]; then
     break

--- a/test/kuttl/common/expected-configs/validate-config.sh
+++ b/test/kuttl/common/expected-configs/validate-config.sh
@@ -43,7 +43,7 @@ mkdir -p "$KUTTL_TEMP_DIR"
 cleanup() {
   if [ -d "$KUTTL_TEMP_DIR" ]; then
     echo "Cleaning up temporary files..."
-    rm -f "$KUTTL_TEMP_DIR"/actual-${CONFIG_TYPE}-*.yaml 2>/dev/null || true
+    rm -f "$KUTTL_TEMP_DIR"/actual-"${CONFIG_TYPE}"-*.yaml 2>/dev/null || true
   fi
 }
 trap cleanup EXIT INT TERM


### PR DESCRIPTION
Add shellcheck for shell script linting and ruff for Python linting and formatting to pre-commit. Fix all existing shellcheck warnings:

- Quote `$POSTGRESQL_DATABASE` in postgres_bootstrap.sh
- Quote `${CONFIG_TYPE}` glob in validate-config.sh
- Quote `${VECTOR_DB_DIR}` glob in vector_database_collect.sh
- Suppress SC2016 in `pullspecs_replaceatron.sh` where single-quoted sed patterns are intentional
- Rename unused loop variable in `gen-rhosls.sh`
- Make `vector_database_collect.sh` POSIX-compliant by removing bash-isms (`local`, `pipefail`). The script runs on ubi9-minimal where `/bin/sh` happens to be `bash`, but relying on that is fragile.