### PR TITLE
Follow up on persistent storage changes (PR#107)

### DIFF
--- a/api/v1beta1/openstacklightspeed_types.go
+++ b/api/v1beta1/openstacklightspeed_types.go
@@ -173,7 +173,7 @@ type OpenStackLightspeedStatus struct {
 // +operator-sdk:csv:customresourcedefinitions:resources={{ServiceAccount,v1,lightspeed-app-server}}
 // +operator-sdk:csv:customresourcedefinitions:resources={{NetworkPolicy,v1,lightspeed-app-server}}
 // +operator-sdk:csv:customresourcedefinitions:resources={{NetworkPolicy,v1,lightspeed-postgres-server}}
-// +operator-sdk:csv:customresourcedefinitions:resources={{PersistentVolumeClaim,v1,openstack-lightspeed-data}}
+// +operator-sdk:csv:customresourcedefinitions:resources={{PersistentVolumeClaim,v1,openstack-lightspeed-database}}
 // +operator-sdk:csv:customresourcedefinitions:resources={{ClusterRole,v1,lightspeed-app-server-sar-role}}
 // +operator-sdk:csv:customresourcedefinitions:resources={{ClusterRoleBinding,v1,lightspeed-app-server-sar-role-binding}}
 // +operator-sdk:csv:customresourcedefinitions:resources={{Subscription,v1alpha1}}

--- a/bundle/manifests/openstack-lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/openstack-lightspeed-operator.clusterserviceversion.yaml
@@ -25,7 +25,7 @@ metadata:
       ]
     capabilities: Basic Install
     categories: AI/Machine Learning
-    createdAt: "2026-05-27T08:37:10Z"
+    createdAt: "2026-05-27T13:26:52Z"
     description: AI-powered virtual assistant for Red Hat OpenStack Services on OpenShift
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
@@ -114,7 +114,7 @@ spec:
         name: metrics-reader-token
         version: v1
       - kind: PersistentVolumeClaim
-        name: openstack-lightspeed-data
+        name: openstack-lightspeed-database
         version: v1
       specDescriptors:
       - description: |-

--- a/config/manifests/bases/openstack-lightspeed-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/openstack-lightspeed-operator.clusterserviceversion.yaml
@@ -91,7 +91,7 @@ spec:
         name: metrics-reader-token
         version: v1
       - kind: PersistentVolumeClaim
-        name: openstack-lightspeed-data
+        name: openstack-lightspeed-database
         version: v1
       specDescriptors:
       - description: |-

--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -72,7 +72,7 @@ const (
 	PostgresConfigVolumeMountPath                = "/usr/share/pgsql/postgresql.conf.sample"
 	PostgresDataVolume                           = "postgres-data"
 	PostgresDataVolumeMountPath                  = "/var/lib/pgsql"
-	PostgresDataPVCName                          = "openstack-lightspeed-data"
+	PostgresDataPVCName                          = "openstack-lightspeed-database"
 	PostgresDataPVCDefaultSize                   = "1Gi"
 	PostgresVarRunVolumeName                     = "lightspeed-postgres-var-run"
 	PostgresVarRunVolumeMountPath                = "/var/run/postgresql"

--- a/internal/controller/postgres_reconciler.go
+++ b/internal/controller/postgres_reconciler.go
@@ -252,7 +252,7 @@ func reconcilePostgresPVC(h *common_helper.Helper, ctx context.Context, instance
 			return fmt.Errorf("%w: requested size %s but existing PVC has %s",
 				ErrPostgresPVCSizeMismatch, requestedQty.String(), existingQty.String())
 		}
-		h.GetLogger().Info("Postgres PVC already exists with matching size", "name", pvc.Name)
+		h.GetLogger().Info("Reusing the existing PostgreSQL PVC with a matching size", "name", pvc.Name)
 		return nil
 	}
 

--- a/test/kuttl/common/openstack-lightspeed-instance/assert-openstack-lightspeed-instance.yaml
+++ b/test/kuttl/common/openstack-lightspeed-instance/assert-openstack-lightspeed-instance.yaml
@@ -7,7 +7,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: openstack-lightspeed-data
+  name: openstack-lightspeed-database
   namespace: openstack-lightspeed
 spec:
   accessModes:

--- a/test/kuttl/common/openstack-lightspeed-instance/cleanup-openstack-lightspeed-instance.yaml
+++ b/test/kuttl/common/openstack-lightspeed-instance/cleanup-openstack-lightspeed-instance.yaml
@@ -6,4 +6,8 @@ delete:
     kind: OpenStackLightspeed
     name: openstack-lightspeed
     namespace: openstack-lightspeed
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    name: openstack-lightspeed-database
+    namespace: openstack-lightspeed
 

--- a/test/kuttl/tests/persistent-database/02-cleanup-leftover-pvc.yaml
+++ b/test/kuttl/tests/persistent-database/02-cleanup-leftover-pvc.yaml
@@ -4,5 +4,5 @@ kind: TestStep
 delete:
   - apiVersion: v1
     kind: PersistentVolumeClaim
-    name: openstack-lightspeed-data
+    name: openstack-lightspeed-database
     namespace: openstack-lightspeed

--- a/test/kuttl/tests/persistent-database/04-assert-openstack-lightspeed-instance.yaml
+++ b/test/kuttl/tests/persistent-database/04-assert-openstack-lightspeed-instance.yaml
@@ -7,7 +7,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: openstack-lightspeed-data
+  name: openstack-lightspeed-database
   namespace: openstack-lightspeed
 spec:
   accessModes:


### PR DESCRIPTION
This patch addresses the latest review nits from PR#107.
    
* Rename the database to "openstack-lightspeed-database"
* Improve the info message when reusing an existing PVC with a matching
   size
