### PR TITLE
Fix default log level for Dataverse

### DIFF
--- a/api/v1beta1/openstacklightspeed_types.go
+++ b/api/v1beta1/openstacklightspeed_types.go
@@ -89,8 +89,9 @@ type OpenStackLightspeedSpec struct {
 // LoggingConfig defines logging configuration for OpenStackLightspeed components
 type LoggingConfig struct {
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default="all=info"
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="OGX Log Level"
-	// Log level configuration for the OGX/llama-stack container. Supports standard levels (INFO, DEBUG) or fine-grained control using format "component=level,component=level" (e.g., "core=debug,providers=info"). Defaults to "all=info" if empty.
+	// Log level configuration for the OGX/llama-stack container. Supports standard levels (INFO, DEBUG) or fine-grained control using format "component=level,component=level" (e.g., "core=debug,providers=info").
 	OGXLogLevel string `json:"ogxLogLevel,omitempty"`
 
 	// +kubebuilder:validation:Optional
@@ -162,8 +163,9 @@ type OpenStackLightspeedCore struct {
 	TranscriptsDisabled bool `json:"transcriptsDisabled,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default={}
 	// Logging configuration for OpenStackLightspeed components
-	Logging LoggingConfig `json:"logging,omitempty"`
+	Logging LoggingConfig `json:"logging"`
 }
 
 // OpenStackLightspeedStatus defines the observed state of OpenStackLightspeed

--- a/bundle/manifests/lightspeed.openstack.org_openstacklightspeeds.yaml
+++ b/bundle/manifests/lightspeed.openstack.org_openstacklightspeeds.yaml
@@ -108,6 +108,7 @@ spec:
                 description: Project ID for LLM providers that require it (e.g., WatsonX)
                 type: string
               logging:
+                default: {}
                 description: Logging configuration for OpenStackLightspeed components
                 properties:
                   dataverseExporterLogLevel:
@@ -135,10 +136,10 @@ spec:
                     - CRITICAL
                     type: string
                   ogxLogLevel:
+                    default: all=info
                     description: Log level configuration for the OGX/llama-stack container.
                       Supports standard levels (INFO, DEBUG) or fine-grained control
                       using format "component=level,component=level" (e.g., "core=debug,providers=info").
-                      Defaults to "all=info" if empty.
                     type: string
                 type: object
               maxTokensForResponse:

--- a/bundle/manifests/openstack-lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/openstack-lightspeed-operator.clusterserviceversion.yaml
@@ -138,7 +138,7 @@ spec:
         path: logging.lightspeedStackLogLevel
       - description: Log level configuration for the OGX/llama-stack container. Supports
           standard levels (INFO, DEBUG) or fine-grained control using format "component=level,component=level"
-          (e.g., "core=debug,providers=info"). Defaults to "all=info" if empty.
+          (e.g., "core=debug,providers=info").
         displayName: OGX Log Level
         path: logging.ogxLogLevel
       - description: Name of the model to use at the API endpoint provided in LLMEndpoint

--- a/config/crd/bases/lightspeed.openstack.org_openstacklightspeeds.yaml
+++ b/config/crd/bases/lightspeed.openstack.org_openstacklightspeeds.yaml
@@ -108,6 +108,7 @@ spec:
                 description: Project ID for LLM providers that require it (e.g., WatsonX)
                 type: string
               logging:
+                default: {}
                 description: Logging configuration for OpenStackLightspeed components
                 properties:
                   dataverseExporterLogLevel:
@@ -135,10 +136,10 @@ spec:
                     - CRITICAL
                     type: string
                   ogxLogLevel:
+                    default: all=info
                     description: Log level configuration for the OGX/llama-stack container.
                       Supports standard levels (INFO, DEBUG) or fine-grained control
                       using format "component=level,component=level" (e.g., "core=debug,providers=info").
-                      Defaults to "all=info" if empty.
                     type: string
                 type: object
               maxTokensForResponse:

--- a/config/manifests/bases/openstack-lightspeed-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/openstack-lightspeed-operator.clusterserviceversion.yaml
@@ -115,7 +115,7 @@ spec:
         path: logging.lightspeedStackLogLevel
       - description: Log level configuration for the OGX/llama-stack container. Supports
           standard levels (INFO, DEBUG) or fine-grained control using format "component=level,component=level"
-          (e.g., "core=debug,providers=info"). Defaults to "all=info" if empty.
+          (e.g., "core=debug,providers=info").
         displayName: OGX Log Level
         path: logging.ogxLogLevel
       - description: Name of the model to use at the API endpoint provided in LLMEndpoint

--- a/internal/controller/lcore_deployment.go
+++ b/internal/controller/lcore_deployment.go
@@ -672,9 +672,6 @@ func buildLightspeedStackReadinessProbe() *corev1.Probe {
 // Defaults to "all=info" if not specified.
 func getOGXLogLevel(instance *apiv1beta1.OpenStackLightspeed) string {
 	logLevel := instance.Spec.Logging.OGXLogLevel
-	if logLevel == "" {
-		return "all=info"
-	}
 
 	// If it's a simple level (INFO, DEBUG, etc.), convert to "all=<level>" format
 	// Otherwise, pass through for fine-grained control (e.g., "core=debug,providers=info")
@@ -684,7 +681,6 @@ func getOGXLogLevel(instance *apiv1beta1.OpenStackLightspeed) string {
 		return fmt.Sprintf("all=%s", strings.ToLower(logLevel))
 	}
 
-	// Pass through as-is for fine-grained control
 	return logLevel
 }
 


### PR DESCRIPTION
The Dataverse exporter crashes with `invalid choice: ''` when a CR omits the logging section, because the empty Go zero value is passed as --log-level "" [1].

Make the logging section default value an empty dict '{}' so OCP always populates it with default values. Also, add a kubebuilder default of "all=info" to ogxLogLevel and remove the runtime empty-string fallback from getOGXLogLevel since the CRD now guarantees a value.

[1] 9f5e97b2b2162497f70e3654e7e05f031adfcc82