### PR TITLE
Add memory and CPU resource limits to containers

### DIFF
--- a/internal/controller/common.go
+++ b/internal/controller/common.go
@@ -99,15 +99,6 @@ func generatePostgresSelectorLabels() map[string]string {
 	}
 }
 
-// getResourcesOrDefault returns the provided resource requirements if non-nil,
-// otherwise returns the given default resource requirements.
-func getResourcesOrDefault(custom *corev1.ResourceRequirements, defaults corev1.ResourceRequirements) corev1.ResourceRequirements {
-	if custom != nil {
-		return *custom
-	}
-	return defaults
-}
-
 // isDeploymentReady checks whether the provided deployment is ready by verifying
 // that the deployment's observed generation matches the current generation and
 // all replicas (updated, available, and total) match the desired count.

--- a/internal/controller/console_deployment.go
+++ b/internal/controller/console_deployment.go
@@ -23,6 +23,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -85,6 +86,16 @@ func buildConsoleDeploymentSpec(consoleImage string) appsv1.DeploymentSpec {
 							"awk '" + consoleLocalesRewriteAwk + "' " +
 								consoleLocalesPath + " > /locales-rewrite/" + consoleLocalesFilename,
 						},
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("50m"),
+								corev1.ResourceMemory: resource.MustParse("64Mi"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("200m"),
+								corev1.ResourceMemory: resource.MustParse("256Mi"),
+							},
+						},
 						VolumeMounts: []corev1.VolumeMount{
 							{
 								Name:      "locales-rewrite",
@@ -107,6 +118,16 @@ func buildConsoleDeploymentSpec(consoleImage string) appsv1.DeploymentSpec {
 						ImagePullPolicy: corev1.PullAlways,
 						SecurityContext: &corev1.SecurityContext{
 							AllowPrivilegeEscalation: toPtr(false),
+						},
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("50m"),
+								corev1.ResourceMemory: resource.MustParse("64Mi"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("200m"),
+								corev1.ResourceMemory: resource.MustParse("256Mi"),
+							},
 						},
 						VolumeMounts: []corev1.VolumeMount{
 							{

--- a/internal/controller/lcore_deployment.go
+++ b/internal/controller/lcore_deployment.go
@@ -81,7 +81,16 @@ func buildLCorePodTemplateSpec(h *common_helper.Helper, ctx context.Context, ins
 			InitialDelaySeconds: 5,
 			PeriodSeconds:       10,
 		},
-		Resources:       getResourcesOrDefault(nil, corev1.ResourceRequirements{}),
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("500m"),
+				corev1.ResourceMemory: resource.MustParse("2Gi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
+			},
+		},
 		ImagePullPolicy: corev1.PullIfNotPresent,
 	}
 
@@ -108,15 +117,24 @@ func buildLCorePodTemplateSpec(h *common_helper.Helper, ctx context.Context, ins
 	}
 
 	lightspeedStackContainer := corev1.Container{
-		Name:            "lightspeed-service-api",
-		Image:           apiv1beta1.OpenStackLightspeedDefaultValues.LCoreImageURL,
-		Args:            []string{"-c", VectorDBVolumeLightspeedStackConfigPath},
-		Ports:           []corev1.ContainerPort{{Name: "https", ContainerPort: OpenStackLightspeedAppServerContainerPort}},
-		VolumeMounts:    lightspeedStackMounts,
-		Env:             lsEnvVars,
-		LivenessProbe:   buildLightspeedStackLivenessProbe(),
-		ReadinessProbe:  buildLightspeedStackReadinessProbe(),
-		Resources:       getResourcesOrDefault(nil, corev1.ResourceRequirements{}),
+		Name:           "lightspeed-service-api",
+		Image:          apiv1beta1.OpenStackLightspeedDefaultValues.LCoreImageURL,
+		Args:           []string{"-c", VectorDBVolumeLightspeedStackConfigPath},
+		Ports:          []corev1.ContainerPort{{Name: "https", ContainerPort: OpenStackLightspeedAppServerContainerPort}},
+		VolumeMounts:   lightspeedStackMounts,
+		Env:            lsEnvVars,
+		LivenessProbe:  buildLightspeedStackLivenessProbe(),
+		ReadinessProbe: buildLightspeedStackReadinessProbe(),
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("250m"),
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("2Gi"),
+			},
+		},
 		ImagePullPolicy: corev1.PullIfNotPresent,
 	}
 	containers := []corev1.Container{llamaStackContainer, lightspeedStackContainer}

--- a/internal/controller/postgres_deployment.go
+++ b/internal/controller/postgres_deployment.go
@@ -149,6 +149,7 @@ func buildPostgresPodTemplateSpec() corev1.PodTemplateSpec {
 							corev1.ResourceMemory: resource.MustParse("300Mi"),
 						},
 						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("500m"),
 							corev1.ResourceMemory: resource.MustParse("2Gi"),
 						},
 					},

--- a/test/kuttl/common/openstack-lightspeed-instance/assert-openstack-lightspeed-instance.yaml
+++ b/test/kuttl/common/openstack-lightspeed-instance/assert-openstack-lightspeed-instance.yaml
@@ -159,6 +159,13 @@ spec:
         - name: vector-database-config-build
       containers:
         - name: llama-stack
+          resources:
+            requests:
+              cpu: 500m
+              memory: 2Gi
+            limits:
+              cpu: "2"
+              memory: 8Gi
           env:
             - name: OPENSTACK_LIGHTSPEED_PROVIDER_API_KEY
               valueFrom:
@@ -186,6 +193,13 @@ spec:
             - name: llama-cache
               mountPath: /tmp/llama-stack
         - name: lightspeed-service-api
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 2Gi
           env:
             - name: LIGHTSPEED_STACK_LOG_LEVEL
               value: WARNING
@@ -309,9 +323,25 @@ spec:
             readOnlyRootFilesystem: true
             capabilities:
               drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
           volumeMounts:
             - name: locales-rewrite
               mountPath: /locales-rewrite
+      containers:
+        - name: lightspeed-console-plugin
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
 ---
 apiVersion: v1
 kind: Service

--- a/test/kuttl/common/openstack-lightspeed-instance/assert-openstack-lightspeed-instance.yaml
+++ b/test/kuttl/common/openstack-lightspeed-instance/assert-openstack-lightspeed-instance.yaml
@@ -41,6 +41,18 @@ kind: Deployment
 metadata:
   name: lightspeed-postgres-server
   namespace: openstack-lightspeed
+spec:
+  template:
+    spec:
+      containers:
+        - name: lightspeed-postgres-server
+          resources:
+            requests:
+              cpu: 30m
+              memory: 300Mi
+            limits:
+              cpu: 500m
+              memory: 2Gi
 status:
   replicas: 1
   readyReplicas: 1

--- a/test/kuttl/tests/update-openstacklightspeed/08-assert-openstacklightspeed-update.yaml
+++ b/test/kuttl/tests/update-openstacklightspeed/08-assert-openstacklightspeed-update.yaml
@@ -23,6 +23,18 @@ kind: Deployment
 metadata:
   name: lightspeed-postgres-server
   namespace: openstack-lightspeed
+spec:
+  template:
+    spec:
+      containers:
+        - name: lightspeed-postgres-server
+          resources:
+            requests:
+              cpu: 30m
+              memory: 300Mi
+            limits:
+              cpu: 500m
+              memory: 2Gi
 status:
   replicas: 1
   readyReplicas: 1

--- a/test/kuttl/tests/update-openstacklightspeed/08-assert-openstacklightspeed-update.yaml
+++ b/test/kuttl/tests/update-openstacklightspeed/08-assert-openstacklightspeed-update.yaml
@@ -74,6 +74,13 @@ spec:
         - name: vector-database-config-build
       containers:
         - name: llama-stack
+          resources:
+            requests:
+              cpu: 500m
+              memory: 2Gi
+            limits:
+              cpu: "2"
+              memory: 8Gi
           env:
             - name: OPENSTACK_LIGHTSPEED_PROVIDER_API_KEY
               valueFrom:
@@ -103,6 +110,13 @@ spec:
             - name: llama-cache
               mountPath: /tmp/llama-stack
         - name: lightspeed-service-api
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 2Gi
           env:
             - name: LIGHTSPEED_STACK_LOG_LEVEL
               value: ERROR
@@ -199,6 +213,13 @@ spec:
     spec:
       initContainers:
         - name: rewrite-locales
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
           volumeMounts:
             - name: locales-rewrite
               mountPath: /locales-rewrite


### PR DESCRIPTION
  - Add memory and CPU resource limits to `llama-stack` container 
  (requests: 500m CPU / 2Gi memory, limits: 2 CPU / 8Gi memory)
  - Add memory and CPU resource limits to `lightspeed-service-api` container
  (requests: 250m CPU / 512Mi memory, limits: 1 CPU / 2Gi memory)
  - Add memory and CPU resource limits to console plugin containers 
  (requests: 50m CPU / 64Mi memory, limits: 200m CPU / 256Mi memory)
  - Update kuttl test assertions to verify resource limits