### PR TITLE
Add support for gemini

### DIFF
--- a/api/v1beta1/openstacklightspeed_types.go
+++ b/api/v1beta1/openstacklightspeed_types.go
@@ -155,7 +155,7 @@ type OpenStackLightspeedCore struct {
 	LLMEndpoint string `json:"llmEndpoint"`
 
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Enum=azure_openai;bam;openai;watsonx;rhoai_vllm;rhelai_vllm;fake_provider
+	// +kubebuilder:validation:Enum=azure_openai;bam;openai;watsonx;rhoai_vllm;rhelai_vllm;fake_provider;gemini
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Provider Type"
 	// Type of the provider serving the LLM
 	LLMEndpointType string `json:"llmEndpointType"`

--- a/bundle/manifests/lightspeed.openstack.org_openstacklightspeeds.yaml
+++ b/bundle/manifests/lightspeed.openstack.org_openstacklightspeeds.yaml
@@ -109,6 +109,7 @@ spec:
                 - rhoai_vllm
                 - rhelai_vllm
                 - fake_provider
+                - gemini
                 type: string
               llmProjectID:
                 description: Project ID for LLM providers that require it (e.g., WatsonX)

--- a/config/crd/bases/lightspeed.openstack.org_openstacklightspeeds.yaml
+++ b/config/crd/bases/lightspeed.openstack.org_openstacklightspeeds.yaml
@@ -109,6 +109,7 @@ spec:
                 - rhoai_vllm
                 - rhelai_vllm
                 - fake_provider
+                - gemini
                 type: string
               llmProjectID:
                 description: Project ID for LLM providers that require it (e.g., WatsonX)

--- a/internal/controller/llama_stack_config.go
+++ b/internal/controller/llama_stack_config.go
@@ -122,16 +122,20 @@ func buildLlamaStackInferenceProviders(_ *common_helper.Helper, _ context.Contex
 
 		// Map provider types to Llama Stack provider types
 		switch provider.Type {
-		case "openai", "rhoai_vllm", "rhelai_vllm":
+		case "openai", "gemini", "rhoai_vllm", "rhelai_vllm":
 			config := map[string]interface{}{}
 			// Determine the appropriate Llama Stack provider type:
 			//  - OpenAI uses remote::openai
 			//  - vLLM uses remote::vllm
 			var apiKeyField string
-			if provider.Type == "openai" {
+			switch provider.Type {
+			case "openai":
 				providerConfig["provider_type"] = "remote::openai"
 				apiKeyField = "api_key"
-			} else {
+			case "gemini":
+				providerConfig["provider_type"] = "remote::gemini"
+				apiKeyField = "api_key"
+			default:
 				providerConfig["provider_type"] = "remote::vllm"
 				apiKeyField = "api_token"
 			}
@@ -173,11 +177,11 @@ func buildLlamaStackInferenceProviders(_ *common_helper.Helper, _ context.Contex
 		case "watsonx", "bam":
 			// These providers are not supported by Llama Stack
 			// They are handled directly by lightspeed-stack (LCS), not Llama Stack
-			return nil, fmt.Errorf("provider type '%s' (provider '%s') is not currently supported by Llama Stack. Supported types: openai, azure_openai, rhoai_vllm, rhelai_vllm", provider.Type, provider.Name)
+			return nil, fmt.Errorf("provider type '%s' (provider '%s') is not currently supported by Llama Stack. Supported types: openai, gemini, azure_openai, rhoai_vllm, rhelai_vllm", provider.Type, provider.Name)
 
 		default:
 			// Unknown provider type
-			return nil, fmt.Errorf("unknown provider type '%s' (provider '%s'). Supported types: openai, azure_openai, rhoai_vllm, rhelai_vllm", provider.Type, provider.Name)
+			return nil, fmt.Errorf("unknown provider type '%s' (provider '%s'). Supported types: openai, gemini, azure_openai, rhoai_vllm, rhelai_vllm", provider.Type, provider.Name)
 		}
 
 		providers = append(providers, providerConfig)


### PR DESCRIPTION
NOTE: gemini should work as is, but in order to enable gemini tool calling this fix is also needed https://github.com/ogx-ai/ogx/pull/5082

Works like this:

apiVersion: lightspeed.openstack.org/v1beta1
kind: OpenStackLightspeed
metadata:
  name: gemini
spec:
  llmEndpoint: https://generativelanguage.googleapis.com/v1beta/openai
  llmEndpointType: gemini
  llmCredentials: gemini-secret
  modelName: models/gemini-2.5-flash
  lcore:
    models:
      - metadata: {}
        model_id: models/gemini-2.5-flash
        provider_id: gemini
        provider_model_id: models/gemini-2.5-flash