### PR TITLE
Use local OKP embeddings from rag-content

### DIFF
--- a/api/v1beta1/openstacklightspeed_types.go
+++ b/api/v1beta1/openstacklightspeed_types.go
@@ -25,11 +25,8 @@ import (
 )
 
 const (
-	// TODO(lpiwowar): Replace this with a stable (non-alpha) image version once
-	// the automated pipeline for building OGX-compatible vector database images
-	// is ready.
 	// OpenStackLightspeedContainerImage is the fall-back container image for OpenStackLightspeed
-	OpenStackLightspeedContainerImage = "quay.io/openstack-lightspeed/rag-content:alpha-ogx-os-docs-2025.2"
+	OpenStackLightspeedContainerImage = "quay.io/openstack-lightspeed/rag-content:os-docs-2026.1-ogx"
 
 	// LCoreContainerImage is the fall-back container image for LCore
 	LCoreContainerImage = "quay.io/lightspeed-core/lightspeed-stack:dev-latest"

--- a/bundle/manifests/openstack-lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/openstack-lightspeed-operator.clusterserviceversion.yaml
@@ -292,7 +292,7 @@ spec:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
                 - name: RELATED_IMAGE_OPENSTACK_LIGHTSPEED_IMAGE_URL_DEFAULT
-                  value: quay.io/openstack-lightspeed/rag-content:alpha-ogx-os-docs-2025.2
+                  value: quay.io/openstack-lightspeed/rag-content:os-docs-2026.1-ogx
                 - name: RELATED_IMAGE_LCORE_IMAGE_URL_DEFAULT
                   value: quay.io/lightspeed-core/lightspeed-stack:dev-latest
                 - name: RELATED_IMAGE_EXPORTER_IMAGE_URL_DEFAULT
@@ -478,7 +478,7 @@ spec:
     name: Red Hat
     url: https://github.com/openstack-lightspeed/operator
   relatedImages:
-  - image: quay.io/openstack-lightspeed/rag-content:alpha-ogx-os-docs-2025.2
+  - image: quay.io/openstack-lightspeed/rag-content:os-docs-2026.1-ogx
     name: openstack-lightspeed-image-url-default
   - image: quay.io/lightspeed-core/lightspeed-stack:dev-latest
     name: lcore-image-url-default

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -74,7 +74,7 @@ spec:
             # the automated pipeline for building OGX-compatible vector database images
             # is ready.
           - name: RELATED_IMAGE_OPENSTACK_LIGHTSPEED_IMAGE_URL_DEFAULT
-            value: quay.io/openstack-lightspeed/rag-content:alpha-ogx-os-docs-2025.2
+            value: quay.io/openstack-lightspeed/rag-content:os-docs-2026.1-ogx
           - name: RELATED_IMAGE_LCORE_IMAGE_URL_DEFAULT
             value: quay.io/lightspeed-core/lightspeed-stack:dev-latest
           - name: RELATED_IMAGE_EXPORTER_IMAGE_URL_DEFAULT

--- a/config/manifests/bases/openstack-lightspeed-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/openstack-lightspeed-operator.clusterserviceversion.yaml
@@ -171,6 +171,6 @@ spec:
   relatedImages:
   - image: quay.io/openstack-lightspeed/operator:latest
     name: operator
-  - image: quay.io/openstack-lightspeed/rag-content:os-docs-2025.2
+  - image: quay.io/openstack-lightspeed/rag-content:os-docs-2026.1-ogx
     name: rag-content
   version: 0.0.0

--- a/hack/env.sh
+++ b/hack/env.sh
@@ -5,7 +5,7 @@ export RELATED_IMAGE_POSTGRES_IMAGE_URL_DEFAULT="registry.redhat.io/rhel9/postgr
 # TODO(lpiwowar): Replace this with a stable (non-alpha) image version once
 # the automated pipeline for building OGX-compatible vector database images
 # is ready.
-export RELATED_IMAGE_OPENSTACK_LIGHTSPEED_IMAGE_URL_DEFAULT="quay.io/openstack-lightspeed/rag-content:alpha-ogx-os-docs-2025.2"
+export RELATED_IMAGE_OPENSTACK_LIGHTSPEED_IMAGE_URL_DEFAULT="quay.io/openstack-lightspeed/rag-content:os-docs-2026.1-ogx"
 export RELATED_IMAGE_OKP_IMAGE_URL_DEFAULT="registry.redhat.io/offline-knowledge-portal/rhokp-rhel9:latest"
 export RELATED_IMAGE_CONSOLE_IMAGE_URL_DEFAULT="registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9:1.0.12"
 export RELATED_IMAGE_CONSOLE_PF5_IMAGE_URL_DEFAULT="registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-pf5-rhel9:1.0.12"

--- a/internal/controller/assets/vector_database_collect.sh
+++ b/internal/controller/assets/vector_database_collect.sh
@@ -38,23 +38,28 @@
 # │   └── ocp_latest/
 # │       ├── faiss_store.db
 # │       └── llama-stack.yaml
-# └── embeddings_model/
+# ├── embeddings_model/
+# │   └── <model_files>
+# └── okp_embeddings_model/
 #     └── <model_files>
 #
 # Output Structure:
 # <target-path>/            (specified via --vector-db-path)
-# └── <random-tmp-dir>/
-#     ├── vector_db/
-#     │   ├── vector-db-data-1/
-#     │   ├── vector-db-data-N/
-#     │   └── ocp_X.YZ/     (if --enable-ocp-rag true and --ocp-version X.YZ)
-#     └── embeddings_model/
-#         └── <model_files>
+# ├── <random-tmp-dir>/
+# │   ├── vector_db/
+# │   │   ├── vector-db-data-1/
+# │   │   ├── vector-db-data-N/
+# │   │   └── ocp_X.YZ/     (if --enable-ocp-rag true and --ocp-version X.YZ)
+# │   └── embeddings_model/
+# │       └── <model_files>
+# └── okp_embeddings_model/  (if --enable-okp true)
+#     └── <model_files>
 #
 # Arguments:
 #  --vector-db-path PATH    Target directory for collected data (required)
 #  --enable-ocp-rag BOOL    Enable OCP vector DB collection: true/false (required)
 #  --ocp-version VERSION    OCP version to collect, e.g., "X.YZ" (required)
+#  --enable-okp             Enable OKP embedding model collection (flag, default: disabled)
 
 set -eu
 
@@ -74,6 +79,11 @@ ENABLE_OCP_RAG=""
 # the vector database image -> ${OCP_VECTOR_DB_DIR}/ocp_${OCP_VERSION}. Populated
 # via parse_arguments_and_init.
 OCP_VERSION=""
+
+# ENABLE_OKP specifies whether this script should collect the OKP embedding
+# model (expected to be found under OKP_EMBEDDING_MODEL_SRC). Defaults to
+# "false"; set to "true" via --enable-okp to enable collection.
+ENABLE_OKP="false"
 # ----------------------------------------------------------------------------
 
 # -- Global vars -------------------------------------------------------------
@@ -110,6 +120,10 @@ VECTOR_DB_DIR="/rag/vector_db"
 # where embeddings model must reside.
 EMBEDDINGS_MODEL_DIR="/rag/embeddings_model"
 
+# OKP_EMBEDDING_MODEL_SRC specifies the directory within the vector DB container
+# image where the OKP embedding model must reside.
+OKP_EMBEDDING_MODEL_SRC="/rag/okp_embeddings_model"
+
 # OGX_CONFIG_FILE_NAME is the name of the OGX config file associated with a
 # single vector database.
 OGX_CONFIG_FILE_NAME="llama-stack.yaml"
@@ -134,13 +148,18 @@ parse_arguments_and_init() {
                 OCP_VERSION="$2"
                 shift 2
                 ;;
+            --enable-okp)
+                ENABLE_OKP="true"
+                shift 1
+                ;;
             -h|--help)
-                echo "Usage: $0 --vector-db-path PATH --enable-ocp-rag BOOL --ocp-version VERSION"
+                echo "Usage: $0 --vector-db-path PATH --enable-ocp-rag BOOL --ocp-version VERSION [--enable-okp]"
                 echo ""
                 echo "Arguments:"
                 echo "  --vector-db-path     Target path for vector DB data collection"
                 echo "  --enable-ocp-rag     Enable OCP RAG collection (true/false)"
                 echo "  --ocp-version        OCP version to collect (e.g., 4.16)"
+                echo "  --enable-okp         Enable OKP embedding model collection (default: disabled)"
                 echo "  -h, --help           Show this help message"
                 exit 0
                 ;;
@@ -246,6 +265,24 @@ collect_embeddings_model() {
     echo "Discovered and collected embeddings model data from ${EMBEDDINGS_MODEL_DIR}"
 }
 
+collect_okp_embeddings_model() {
+    if [ "${ENABLE_OKP}" != "true" ]; then
+        echo "Collecting of OKP embedding model is DISABLED => Skipping"
+        return
+    fi
+
+    if [ ! -d "${OKP_EMBEDDING_MODEL_SRC}" ]; then
+        echo "ERROR: OKP embedding model dir not found under ${OKP_EMBEDDING_MODEL_SRC}."
+        exit 1
+    fi
+
+    echo "Collecting OKP embedding model ..."
+    rm -rf "${VECTOR_DB_VOLUME_MOUNT_PATH}/okp_embeddings_model"
+    mkdir -p "${VECTOR_DB_VOLUME_MOUNT_PATH}/okp_embeddings_model"
+    cp -rL "${OKP_EMBEDDING_MODEL_SRC}/." "${VECTOR_DB_VOLUME_MOUNT_PATH}/okp_embeddings_model"
+    echo "Discovered and collected OKP embedding model from ${OKP_EMBEDDING_MODEL_SRC}"
+}
+
 main() {
     # NOTE: parse_arguments_and_init must be called first to ensure all global
     # variables are initialized before proceeding.
@@ -253,6 +290,7 @@ main() {
     collect_vector_db_data
     collect_ocp_vector_db_data
     collect_embeddings_model
+    collect_okp_embeddings_model
 }
 
 main "$@"

--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -134,6 +134,11 @@ const (
 	// init container responsible for assembling the final Lightspeed Stack config.
 	VectorDBVolumeLightspeedStackConfigPath = VectorDBVolumeMountPath + "/lightspeed-stack.yaml"
 
+	// OKPEmbeddingModelMountPath specifies the path within the VectorDBVolumeName
+	// volume where the OKP embedding model is stored after being extracted from the
+	// rag-content image by the vector-database-collect init container.
+	OKPEmbeddingModelMountPath = VectorDBVolumeMountPath + "/okp_embeddings_model"
+
 	// OGXConfigInitContainerMountPath specifies the path where the operator-generated
 	// OGX config file is mounted in the init container responsible for assembling
 	// the final OGX configuration, which includes information about RAG.

--- a/internal/controller/lcore_deployment.go
+++ b/internal/controller/lcore_deployment.go
@@ -245,12 +245,18 @@ func buildInitContainers(
 	containers = append(containers, corev1.Container{
 		Name:  "vector-database-collect",
 		Image: instance.Spec.RAGImage,
-		Command: []string{
-			"sh", VectorDBScriptsMountPath + "/" + VectorDBCollectScriptKey,
-			"--vector-db-path", VectorDBVolumeMountPath,
-			"--enable-ocp-rag", strconv.FormatBool(instance.Spec.EnableOCPRAG),
-			"--ocp-version", ocp_version,
-		},
+		Command: func() []string {
+			cmd := []string{
+				"sh", VectorDBScriptsMountPath + "/" + VectorDBCollectScriptKey,
+				"--vector-db-path", VectorDBVolumeMountPath,
+				"--enable-ocp-rag", strconv.FormatBool(instance.Spec.EnableOCPRAG),
+				"--ocp-version", ocp_version,
+			}
+			if isOKPEnabled(instance) {
+				cmd = append(cmd, "--enable-okp")
+			}
+			return cmd
+		}(),
 		SecurityContext: securityContext,
 		Resources:       resourceRequirements,
 		VolumeMounts: []corev1.VolumeMount{
@@ -569,13 +575,6 @@ func buildLlamaStackEnvVars(h *common_helper.Helper, ctx context.Context, instan
 		envVars = append(envVars, corev1.EnvVar{
 			Name:  "RH_SERVER_OKP",
 			Value: fmt.Sprintf("http://%s.%s.svc:%d", OKPServiceName, instance.GetNamespace(), OKPServicePort),
-		})
-		// FIXME(lucasagomes): Llama-Stack expects HF_HOME to be set when OKP is enabled because it uses the
-		// Hugging Face Hub client to fetch the embedding model for OKP. Ideally we would include the model it
-		// downloads in the container image to avoid this.
-		envVars = append(envVars, corev1.EnvVar{
-			Name:  "HF_HOME",
-			Value: "/tmp/huggingface",
 		})
 	}
 

--- a/internal/controller/llama_stack_config.go
+++ b/internal/controller/llama_stack_config.go
@@ -257,7 +257,7 @@ func buildOKPVectorIOProvider(instance *apiv1beta1.OpenStackLightspeed) map[stri
 			"content_field":       "${env.SOLR_CONTENT_FIELD:=chunk}",
 			"vector_field":        "${env.SOLR_VECTOR_FIELD:=chunk_vector}",
 			"embedding_dimension": "${env.SOLR_EMBEDDING_DIM:=384}",
-			"embedding_model":     "${env.SOLR_EMBEDDING_MODEL:=sentence-transformers/ibm-granite/granite-embedding-30m-english}",
+			"embedding_model":     "sentence-transformers/" + OKPEmbeddingModelMountPath,
 			"persistence": map[string]interface{}{
 				"backend":   "kv_default",
 				"namespace": "portal-rag",
@@ -366,7 +366,7 @@ func buildLlamaStackModels(_ *common_helper.Helper, instance *apiv1beta1.OpenSta
 			"model_id":          "solr_embedding",
 			"model_type":        "embedding",
 			"provider_id":       "sentence-transformers",
-			"provider_model_id": "${env.SOLR_EMBEDDING_MODEL:=ibm-granite/granite-embedding-30m-english}",
+			"provider_model_id": OKPEmbeddingModelMountPath,
 			"metadata": map[string]interface{}{
 				"embedding_dimension": 384,
 			},
@@ -383,7 +383,7 @@ func buildLlamaStackVectorStores(_ *common_helper.Helper, instance *apiv1beta1.O
 			"vector_store_id":     "portal-rag",
 			"provider_id":         "okp_solr",
 			"embedding_dimension": 384,
-			"embedding_model":     "${env.SOLR_EMBEDDING_MODEL:=sentence-transformers/ibm-granite/granite-embedding-30m-english}",
+			"embedding_model":     "sentence-transformers/" + OKPEmbeddingModelMountPath,
 		})
 	}
 	return stores

--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -6,5 +6,3 @@ reportGranularity: test
 namespace: openstack-lightspeed
 timeout: 1380
 parallel: 1
-suppress:
-  - events

--- a/test/kuttl/common/expected-configs/ogx_config-okp.yaml
+++ b/test/kuttl/common/expected-configs/ogx_config-okp.yaml
@@ -88,7 +88,7 @@ providers:
       collection_name: ${env.SOLR_COLLECTION:=portal-rag}
       content_field: ${env.SOLR_CONTENT_FIELD:=chunk}
       embedding_dimension: ${env.SOLR_EMBEDDING_DIM:=384}
-      embedding_model: ${env.SOLR_EMBEDDING_MODEL:=sentence-transformers/ibm-granite/granite-embedding-30m-english}
+      embedding_model: sentence-transformers//vector-db-discovered-values/okp_embeddings_model
       persistence:
         backend: kv_default
         namespace: portal-rag
@@ -100,7 +100,7 @@ providers:
       persistence:
         namespace: vector_io::faiss
         backend: kv_rag_UUID_os_product_docs
-    provider_id: os-docs-2025.2
+    provider_id: os-docs-2026.1-ogx
     provider_type: inline::faiss
 registered_resources:
   models:
@@ -115,7 +115,7 @@ registered_resources:
     model_id: solr_embedding
     model_type: embedding
     provider_id: sentence-transformers
-    provider_model_id: ${env.SOLR_EMBEDDING_MODEL:=ibm-granite/granite-embedding-30m-english}
+    provider_model_id: /vector-db-discovered-values/okp_embeddings_model
   - metadata:
       embedding_dimension: 768
     model_id: sentence-transformers/all-mpnet-base-v2
@@ -127,12 +127,12 @@ registered_resources:
     toolgroup_id: builtin::rag
   vector_stores:
   - embedding_dimension: 384
-    embedding_model: ${env.SOLR_EMBEDDING_MODEL:=sentence-transformers/ibm-granite/granite-embedding-30m-english}
+    embedding_model: sentence-transformers//vector-db-discovered-values/okp_embeddings_model
     provider_id: okp_solr
     vector_store_id: portal-rag
   - embedding_dimension: 768
     embedding_model: sentence-transformers/${env.VECTOR_DB_DATA_PATH}/UUID/embeddings_model
-    provider_id: os-docs-2025.2
+    provider_id: os-docs-2026.1-ogx
     vector_store_id: vs_UUID
 scoring_fns: []
 server:

--- a/test/kuttl/common/expected-configs/ogx_config-update.yaml
+++ b/test/kuttl/common/expected-configs/ogx_config-update.yaml
@@ -76,7 +76,7 @@ providers:
       persistence:
         namespace: vector_io::faiss
         backend: kv_rag_UUID_os_product_docs
-    provider_id: os-docs-2025.2
+    provider_id: os-docs-2026.1-ogx
     provider_type: inline::faiss
 registered_resources:
   models:
@@ -98,7 +98,7 @@ registered_resources:
   vector_stores:
   - embedding_dimension: 768
     embedding_model: sentence-transformers/${env.VECTOR_DB_DATA_PATH}/UUID/embeddings_model
-    provider_id: os-docs-2025.2
+    provider_id: os-docs-2026.1-ogx
     vector_store_id: vs_UUID
 scoring_fns: []
 server:

--- a/test/kuttl/common/expected-configs/ogx_config.yaml
+++ b/test/kuttl/common/expected-configs/ogx_config.yaml
@@ -76,7 +76,7 @@ providers:
       persistence:
         namespace: vector_io::faiss
         backend: kv_rag_UUID_os_product_docs
-    provider_id: os-docs-2025.2
+    provider_id: os-docs-2026.1-ogx
     provider_type: inline::faiss
 registered_resources:
   models:
@@ -98,7 +98,7 @@ registered_resources:
   vector_stores:
   - embedding_dimension: 768
     embedding_model: sentence-transformers/${env.VECTOR_DB_DATA_PATH}/UUID/embeddings_model
-    provider_id: os-docs-2025.2
+    provider_id: os-docs-2026.1-ogx
     vector_store_id: vs_UUID
 scoring_fns: []
 server:

--- a/test/kuttl/tests/okp-configuration/03-assert-okp-instance.yaml
+++ b/test/kuttl/tests/okp-configuration/03-assert-okp-instance.yaml
@@ -80,8 +80,6 @@ spec:
               value: /vector-db-discovered-values
             - name: RH_SERVER_OKP
               value: http://lightspeed-okp-server.openstack-lightspeed.svc:8080
-            - name: HF_HOME
-              value: /tmp/huggingface
         - name: lightspeed-service-api
           env:
             - name: LIGHTSPEED_STACK_LOG_LEVEL


### PR DESCRIPTION
The rag-content image now ships the OKP embedding model in it and we no longer need for OGX to download it at runtime via HF.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced OKP embedding model integration with improved collection and configuration capabilities.

* **Chores**
  * Updated default container image to 2026.1 version.
  * Simplified OKP environment variable configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->