### PR TITLE
Add missing RELATED_IMAGE_CONSOLE env vars

### DIFF
--- a/bundle/manifests/openstack-lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/openstack-lightspeed-operator.clusterserviceversion.yaml
@@ -25,7 +25,7 @@ metadata:
       ]
     capabilities: Basic Install
     categories: AI/Machine Learning
-    createdAt: "2026-06-11T09:06:59Z"
+    createdAt: "2026-06-22T19:14:00Z"
     description: AI-powered virtual assistant for Red Hat OpenStack Services on OpenShift
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
@@ -301,6 +301,10 @@ spec:
                   value: registry.redhat.io/rhel9/postgresql-16:latest
                 - name: RELATED_IMAGE_OKP_IMAGE_URL_DEFAULT
                   value: registry.redhat.io/offline-knowledge-portal/rhokp-rhel9:latest
+                - name: RELATED_IMAGE_CONSOLE_IMAGE_URL_DEFAULT
+                  value: registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9:1.0.12
+                - name: RELATED_IMAGE_CONSOLE_PF5_IMAGE_URL_DEFAULT
+                  value: registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-pf5-rhel9:1.0.12
                 image: quay.io/openstack-lightspeed/operator:latest
                 livenessProbe:
                   httpGet:
@@ -484,4 +488,8 @@ spec:
     name: postgres-image-url-default
   - image: registry.redhat.io/offline-knowledge-portal/rhokp-rhel9:latest
     name: okp-image-url-default
+  - image: registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9:1.0.12
+    name: console-image-url-default
+  - image: registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-pf5-rhel9:1.0.12
+    name: console-pf5-image-url-default
   version: 0.0.1

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -83,6 +83,10 @@ spec:
             value: registry.redhat.io/rhel9/postgresql-16:latest
           - name: RELATED_IMAGE_OKP_IMAGE_URL_DEFAULT
             value: registry.redhat.io/offline-knowledge-portal/rhokp-rhel9:latest
+          - name: RELATED_IMAGE_CONSOLE_IMAGE_URL_DEFAULT
+            value: registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9:1.0.12
+          - name: RELATED_IMAGE_CONSOLE_PF5_IMAGE_URL_DEFAULT
+            value: registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-pf5-rhel9:1.0.12
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/hack/env.sh
+++ b/hack/env.sh
@@ -7,4 +7,6 @@ export RELATED_IMAGE_POSTGRES_IMAGE_URL_DEFAULT="registry.redhat.io/rhel9/postgr
 # is ready.
 export RELATED_IMAGE_OPENSTACK_LIGHTSPEED_IMAGE_URL_DEFAULT="quay.io/openstack-lightspeed/rag-content:alpha-ogx-os-docs-2025.2"
 export RELATED_IMAGE_OKP_IMAGE_URL_DEFAULT="registry.redhat.io/offline-knowledge-portal/rhokp-rhel9:latest"
+export RELATED_IMAGE_CONSOLE_IMAGE_URL_DEFAULT="registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9:1.0.12"
+export RELATED_IMAGE_CONSOLE_PF5_IMAGE_URL_DEFAULT="registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-pf5-rhel9:1.0.12"
 export WATCH_NAMESPACE="openstack-lightspeed"


### PR DESCRIPTION
Add missing RELATED_IMAGE_CONSOLE env vars to manager.yaml and hack/env.sh. The console image env vars were read in SetupDefaults() but not defined in the operator deployment manifest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated operator configuration to support new console plugin images (version 1.0.12) for OpenShift Lightspeed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->