### PR TITLE
OKP Follow-up

### DIFF
--- a/api/v1beta1/openstacklightspeed_types.go
+++ b/api/v1beta1/openstacklightspeed_types.go
@@ -52,6 +52,11 @@ const (
 
 // DevSpec is the internal structure for the Dev field. Not exposed in the CRD.
 // May change at any time without backward compatibility.
+//
+// Supported fields:
+//   - featureFlags: list of experimental feature flags to enable (e.g. ["okp"])
+//   - okpChunkFilterQuery: Solr filter query for OKP searches (default: "product:(*openstack* OR *openshift*)")
+//   - okpRagOnly: when true, only OKP is used as a RAG source (default: false)
 type DevSpec struct {
 	FeatureFlags        []string `json:"featureFlags,omitempty"`
 	OKPChunkFilterQuery string   `json:"okpChunkFilterQuery,omitempty"`

--- a/internal/controller/assets/vector_database_build.py
+++ b/internal/controller/assets/vector_database_build.py
@@ -221,7 +221,7 @@ def ogx_process(ogx_config_source_path: Path, ogx_config_target: dict[str, Any])
 def lstack_process(
     ogx_config_source_path: Path,
     lstack_config_target: dict[str, Any],
-    okp_rag_only: bool = False,
+    disable_rag_entries: bool = False,
 ) -> dict[str, Any]:
     """Update Lightspeed stack config with RAG entries from OGX config source."""
     ogx_config_source = load_yaml_file(ogx_config_source_path)
@@ -246,7 +246,7 @@ def lstack_process(
         },
     )
 
-    if not okp_rag_only:
+    if not disable_rag_entries:
         add_unique(lstack_config_target["rag"]["inline"], vector_store_id)
     return lstack_config_target
 
@@ -281,10 +281,10 @@ def parse_arguments() -> argparse.Namespace:
         help="Path (as pathlib.Path) to the base Lightspeed Stack configuration file",
     )
     parser.add_argument(
-        "--okp-rag-only",
+        "--disable-rag-entries",
         action="store_true",
         default=False,
-        help="When set, skip adding vector store IDs to rag.inline (OKP is the only RAG source)",
+        help="When set, skip adding vector store IDs to rag.inline",
     )
 
     return parser.parse_args()
@@ -294,7 +294,9 @@ def main() -> None:
     """main"""
     args = parse_arguments()
     config_build(args.vector_db_path, args.ogx_config_path, ogx_process)
-    lstack_fn = functools.partial(lstack_process, okp_rag_only=args.okp_rag_only)
+    lstack_fn = functools.partial(
+        lstack_process, disable_rag_entries=args.disable_rag_entries
+    )
     config_build(args.vector_db_path, args.lightspeed_stack_path, lstack_fn)
 
 

--- a/internal/controller/lcore_deployment.go
+++ b/internal/controller/lcore_deployment.go
@@ -280,7 +280,7 @@ func buildInitContainers(
 	}
 	devConfig, _ := parseDevConfig(instance)
 	if devConfig.OKPRagOnly {
-		configBuildCmd = append(configBuildCmd, "--okp-rag-only")
+		configBuildCmd = append(configBuildCmd, "--disable-rag-entries")
 	}
 
 	containers = append(containers, corev1.Container{


### PR DESCRIPTION
This change includes two commits:

1. Documents the available configurations under the dev: section. The dev: section is an experimental section that is used by developers only therefore it's been documented in code only.

2. In the vector_database_build.py script, the --okp-rag-only option name was a bit misleading so it has been renamed to --disable-rag-entries.

This change is a follow up on the original OKP enablement [PR#110](https://github.com/openstack-lightspeed/operator/pull/110)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for internal developer configuration options, detailing supported settings for feature flags and RAG (Retrieval-Augmented Generation) behavior with example values and default configurations.

* **Chores**
  * Renamed vector database configuration flag from `--okp-rag-only` to `--disable-rag-entries` to better reflect its functionality and improve code clarity.
  * Updated corresponding configuration injection logic to align with the new flag naming convention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->