### PR TITLE
Add PGSSLMODE and PGSSLROOTCERT env vars to OGX container

### DIFF
--- a/internal/controller/lcore_deployment.go
+++ b/internal/controller/lcore_deployment.go
@@ -549,6 +549,19 @@ func buildLlamaStackEnvVars(h *common_helper.Helper, ctx context.Context, instan
 	// Postgres password for ${env.POSTGRES_PASSWORD} substitution in llama-stack config
 	envVars = append(envVars, buildPostgresPasswordEnvVar())
 
+	// PostgreSQL SSL configuration for OGX (llama-stack).
+	// OGX's PostgresSqlStoreConfig does not support ssl_mode/ca_cert_path fields yet
+	// (ogx-ai/ogx#5978), so we configure asyncpg via standard libpq environment
+	// variables to enforce TLS with full certificate verification.
+	envVars = append(envVars, corev1.EnvVar{
+		Name:  "PGSSLMODE",
+		Value: PostgresDefaultSSLMode,
+	})
+	envVars = append(envVars, corev1.EnvVar{
+		Name:  "PGSSLROOTCERT",
+		Value: CABundleMountPath,
+	})
+
 	// Logging configuration - set both for compatibility with llama-stack and OGX
 	ogxLogLevel := getOGXLogLevel(instance)
 	envVars = append(envVars, corev1.EnvVar{

--- a/test/kuttl/common/openstack-lightspeed-instance/assert-openstack-lightspeed-instance.yaml
+++ b/test/kuttl/common/openstack-lightspeed-instance/assert-openstack-lightspeed-instance.yaml
@@ -189,6 +189,10 @@ spec:
                 secretKeyRef:
                   key: password
                   name: lightspeed-postgres-secret
+            - name: PGSSLMODE
+              value: verify-full
+            - name: PGSSLROOTCERT
+              value: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
             - name: LLAMA_STACK_LOGGING
               value: all=debug
             - name: OGX_LOGGING

--- a/test/kuttl/tests/okp-configuration/03-assert-okp-instance.yaml
+++ b/test/kuttl/tests/okp-configuration/03-assert-okp-instance.yaml
@@ -72,6 +72,10 @@ spec:
                 secretKeyRef:
                   key: password
                   name: lightspeed-postgres-secret
+            - name: PGSSLMODE
+              value: verify-full
+            - name: PGSSLROOTCERT
+              value: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
             - name: LLAMA_STACK_LOGGING
               value: all=debug
             - name: OGX_LOGGING

--- a/test/kuttl/tests/update-openstacklightspeed/08-assert-openstacklightspeed-update.yaml
+++ b/test/kuttl/tests/update-openstacklightspeed/08-assert-openstacklightspeed-update.yaml
@@ -106,6 +106,10 @@ spec:
                 secretKeyRef:
                   key: password
                   name: lightspeed-postgres-secret
+            - name: PGSSLMODE
+              value: verify-full
+            - name: PGSSLROOTCERT
+              value: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
             - name: LLAMA_STACK_LOGGING
               value: core=debug,providers=info
             - name: OGX_LOGGING


### PR DESCRIPTION
**Title:** Secure OGX-to-PostgreSQL connection with TLS certificate verification

**Body:**

### Summary

- Add `PGSSLMODE=verify-full` and `PGSSLROOTCERT` environment variables to the OGX (llama-stack) container to enforce TLS with full certificate verification on the PostgreSQL connection.
- This achieves parity with lightspeed-stack, which already connects with `ssl_mode: verify-full`.

### Why env vars instead of config fields?

OGX's `PostgresSqlStoreConfig` does not support `ssl_mode` or `ca_cert_path` fields yet ([ogx-ai/ogx#5978](https://github.com/ogx-ai/ogx/issues/5978)). There is an open upstream PR to add support ([ogx-ai/ogx#5996](https://github.com/ogx-ai/ogx/pull/5996)), but it has unresolved review feedback.

`asyncpg` (the PostgreSQL driver OGX uses) reads `PGSSLMODE` and `PGSSLROOTCERT` as fallbacks when SSL isn't configured via params directly — verified in the [asyncpg source](https://github.com/MagicStack/asyncpg/blob/master/asyncpg/connect_utils.py). The CA bundle is already mounted into the container.

### Follow-up

Once ogx-ai/ogx#5996 merges, a follow-up ticket will replace the env var workaround with native `ssl_mode` and `ca_cert_path` config fields in `llama_stack_config.go`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * PostgreSQL SSL/TLS encryption is now configured for database connections, enabling certificate verification and CA bundle path configuration for enhanced security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->