### PR TITLE
Use HTTP health check for llama-stack/ogx container

### DIFF
--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -76,6 +76,14 @@ const (
 	LCoreConfigMountPath     = "/app-root/lightspeed-stack.yaml"
 	LCoreUserDataMountPath   = "/tmp/data"
 	ForceReloadAnnotationKey = "ols.openshift.io/force-reload"
+	// Health probe settings for the llama-stack/OGX container.
+	// The startup probe allows up to 30 failures (300s) for the slow initialization,
+	// while liveness and readiness probes use a tighter threshold of 3 failures.
+	LlamaStackHealthPath                   = "/v1/health"
+	LlamaStackProbePeriodSeconds           = int32(10)
+	LlamaStackProbeTimeoutSeconds          = int32(5)
+	LlamaStackStartupProbeFailureThreshold = int32(30)
+	LlamaStackProbeFailureThreshold        = int32(3)
 
 	// Data Exporter
 	ExporterConfigVolumeName       = "exporter-config"

--- a/internal/controller/lcore_deployment.go
+++ b/internal/controller/lcore_deployment.go
@@ -72,14 +72,38 @@ func buildLCorePodTemplateSpec(h *common_helper.Helper, ctx context.Context, ins
 		Ports:        []corev1.ContainerPort{{Name: "llama-stack", ContainerPort: LlamaStackContainerPort}},
 		VolumeMounts: llamaStackMounts,
 		Env:          llamaEnvVars,
-		ReadinessProbe: &corev1.Probe{
+		StartupProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
-				TCPSocket: &corev1.TCPSocketAction{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: LlamaStackHealthPath,
 					Port: intstr.FromInt32(LlamaStackContainerPort),
 				},
 			},
-			InitialDelaySeconds: 5,
-			PeriodSeconds:       10,
+			PeriodSeconds:    LlamaStackProbePeriodSeconds,
+			TimeoutSeconds:   LlamaStackProbeTimeoutSeconds,
+			FailureThreshold: LlamaStackStartupProbeFailureThreshold,
+		},
+		LivenessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: LlamaStackHealthPath,
+					Port: intstr.FromInt32(LlamaStackContainerPort),
+				},
+			},
+			PeriodSeconds:    LlamaStackProbePeriodSeconds,
+			TimeoutSeconds:   LlamaStackProbeTimeoutSeconds,
+			FailureThreshold: LlamaStackProbeFailureThreshold,
+		},
+		ReadinessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: LlamaStackHealthPath,
+					Port: intstr.FromInt32(LlamaStackContainerPort),
+				},
+			},
+			PeriodSeconds:    LlamaStackProbePeriodSeconds,
+			TimeoutSeconds:   LlamaStackProbeTimeoutSeconds,
+			FailureThreshold: LlamaStackProbeFailureThreshold,
 		},
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{


### PR DESCRIPTION
Replace the TCP socket readiness probe with a proper HTTP GET on /v1/health.

Also, add a startup probe and liveness probe that will start only after the startup one succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application health checks to use the service’s HTTP health endpoint, helping detect readiness, startup, and runtime issues more reliably.
  * Added startup and liveness checks so the service can recover more consistently from slow starts or unexpected failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->