### PR TITLE
Lcore dev improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ go.work
 *.swp
 *.swo
 *~
+
+# Kuttl test files
+kubeconfig
+kuttl-report-openstack-lightspeed.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 FROM golang:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
+ARG GOMAXPROCS
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -21,7 +22,7 @@ COPY internal/controller/ internal/controller/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+RUN GOMAXPROCS=${GOMAXPROCS} CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
 
 .PHONY: build
 build: manifests generate fmt vet ## Build manager binary.
-	go build -o bin/manager cmd/main.go
+	GOMAXPROCS=$(GOMAXPROCS) go build -o bin/manager cmd/main.go
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
@@ -157,7 +157,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.
-	$(CONTAINER_TOOL) build -t ${IMG} .
+	$(CONTAINER_TOOL) build --build-arg GOMAXPROCS=$(GOMAXPROCS) -t ${IMG} .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.

--- a/Makefile
+++ b/Makefile
@@ -219,10 +219,12 @@ openstack-lightspeed-deploy: ## Deploy using a catalog image.
 	oc apply -f $(OUTPUT_DIR)/rhosls
 	bash scripts/confirm-rhosls-running.sh
 
-# Deploy using the catalog image.
+# Undeploy using the catalog image.
+# Remove OpenStackLightspeds so the namespace deletion doesn't get stuck
 .PHONY: openstack-lightspeed-undeploy
 openstack-lightspeed-undeploy: export OUTPUT_DIR = out
 openstack-lightspeed-undeploy: ## Undeploy using a catalog image.
+	oc delete openstacklightspeed --all -n openstack-lightspeed --ignore-not-found=true --timeout=120s
 	find out/{catalog,rhosls} -name "*.yaml" -printf " -f %p" | xargs oc delete --ignore-not-found=true
 
 CATALOG_NAME ?= openstack-lightspeed-catalog
@@ -298,6 +300,20 @@ kuttl-test-ocp: IMG = $(OCP_INTERNAL_REGISTRY)/$(OCP_REGISTRY_NAMESPACE)/operato
 kuttl-test-ocp: BUNDLE_IMG = $(OCP_INTERNAL_REGISTRY)/openshift-marketplace/operator-bundle:$(TAG)
 kuttl-test-ocp: CATALOG_IMG = $(OCP_INTERNAL_REGISTRY)/openshift-marketplace/operator-catalog:$(TAG)
 kuttl-test-ocp: docker-build bundle bundle-build ocp-catalog-build ocp-registry-push kuttl-test-run
+
+.PHONY: ocp-deploy
+ocp-deploy: IMG = $(OCP_INTERNAL_REGISTRY)/$(OCP_REGISTRY_NAMESPACE)/operator:latest
+ocp-deploy: BUNDLE_IMG = $(OCP_INTERNAL_REGISTRY)/openshift-marketplace/operator-bundle:$(TAG)
+ocp-deploy: CATALOG_IMG = $(OCP_INTERNAL_REGISTRY)/openshift-marketplace/operator-catalog:$(TAG)
+ocp-deploy: docker-build bundle bundle-build ocp-catalog-build ocp-registry-push openstack-lightspeed-deploy ## Build, push, and deploy the operator on an OCP cluster.
+
+.PHONY: ocp-deploy-cleanup
+ocp-deploy-cleanup: IMG = $(OCP_INTERNAL_REGISTRY)/$(OCP_REGISTRY_NAMESPACE)/operator:latest
+ocp-deploy-cleanup: BUNDLE_IMG = $(OCP_INTERNAL_REGISTRY)/openshift-marketplace/operator-bundle:$(TAG)
+ocp-deploy-cleanup: CATALOG_IMG = $(OCP_INTERNAL_REGISTRY)/openshift-marketplace/operator-catalog:$(TAG)
+ocp-deploy-cleanup: openstack-lightspeed-undeploy ## Clean up everything created by ocp-deploy.
+	oc delete imagestreamtag operator-catalog:$(TAG) -n openshift-marketplace --ignore-not-found=true
+	oc delete namespace $(OCP_REGISTRY_NAMESPACE) --ignore-not-found=true --wait
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary


### PR DESCRIPTION
Just some small improvements for developers:

- `ocp-deploy` and `ocp-deploy-cleanup` targets
- `GOMAXPROCS` support to limit parallel processes during golang compilation
- Add kuttl test artifacts to .gitignore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved OpenShift deployment flow with a new cleanup step for registry/catalog resources.
  * Added stronger teardown behavior to remove deployed application resources more completely.

* **Bug Fixes**
  * Build and container image creation now propagate CPU settings more consistently, helping ensure more reliable builds in different environments.

* **Chores**
  * Updated ignored test artifacts so temporary KUTTL files are no longer tracked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->