### PR TITLE
Set seccompProfile to RuntimeDefault on operator pods

### DIFF
--- a/bundle/manifests/openstack-lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/openstack-lightspeed-operator.clusterserviceversion.yaml
@@ -244,6 +244,8 @@ spec:
                     - ALL
               securityContext:
                 runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
               serviceAccountName: openstack-lightspeed-operator-controller-manager
               terminationGracePeriodSeconds: 10
       permissions:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -50,13 +50,8 @@ spec:
       #               - linux
       securityContext:
         runAsNonRoot: true
-        # TODO(user): For common cases that do not require escalating privileges
-        # it is recommended to ensure that all your Pods/Containers are restrictive.
-        # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
-        # Please uncomment the following code if your project does NOT have to work on old Kubernetes
-        # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
-        # seccompProfile:
-        #   type: RuntimeDefault
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager


### PR DESCRIPTION
Uncomment and apply the seccompProfile field in manager.yaml and the CSV so that operator pods always run under the RuntimeDefault seccomp profile (make it explicit).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the controller pod’s security settings by enabling the default seccomp profile.
  * Removed outdated commented security configuration to keep deployment settings clearer and more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->