### PR TITLE
Use HTTP health check for lightspeed-stack container

### DIFF
--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -85,6 +85,16 @@ const (
 	LlamaStackStartupProbeFailureThreshold = int32(30)
 	LlamaStackProbeFailureThreshold        = int32(3)
 
+	// Health probe settings for the lightspeed-stack container.
+	// The startup probe allows up to 30 failures (300s) for initialization,
+	// while liveness and readiness probes use a tighter threshold of 3 failures.
+	LightspeedStackLivenessPath                 = "/liveness"
+	LightspeedStackReadinessPath                = "/readiness"
+	LightspeedStackProbePeriodSeconds           = int32(10)
+	LightspeedStackProbeTimeoutSeconds          = int32(5)
+	LightspeedStackStartupProbeFailureThreshold = int32(30)
+	LightspeedStackProbeFailureThreshold        = int32(3)
+
 	// Data Exporter
 	ExporterConfigVolumeName       = "exporter-config"
 	ExporterConfigMountPath        = "/etc/config"

--- a/internal/controller/lcore_config.go
+++ b/internal/controller/lcore_config.go
@@ -112,7 +112,8 @@ func buildLCoreUserDataCollectionConfig(_ *common_helper.Helper, instance *apiv1
 
 func buildLCoreAuthenticationConfig(_ *common_helper.Helper, _ *apiv1beta1.OpenStackLightspeed) map[string]interface{} {
 	return map[string]interface{}{
-		"module": "k8s",
+		"module":                 "k8s",
+		"skip_for_health_probes": true,
 	}
 }
 

--- a/internal/controller/lcore_deployment.go
+++ b/internal/controller/lcore_deployment.go
@@ -147,6 +147,7 @@ func buildLCorePodTemplateSpec(h *common_helper.Helper, ctx context.Context, ins
 		Ports:          []corev1.ContainerPort{{Name: "https", ContainerPort: OpenStackLightspeedAppServerContainerPort}},
 		VolumeMounts:   lightspeedStackMounts,
 		Env:            lsEnvVars,
+		StartupProbe:   buildLightspeedStackStartupProbe(),
 		LivenessProbe:  buildLightspeedStackLivenessProbe(),
 		ReadinessProbe: buildLightspeedStackReadinessProbe(),
 		Resources: corev1.ResourceRequirements{
@@ -651,18 +652,35 @@ func buildLightspeedStackEnvVars(instance *apiv1beta1.OpenStackLightspeed) []cor
 	return envVars
 }
 
+// buildLightspeedStackStartupProbe returns the startup probe for the lightspeed-stack container.
+func buildLightspeedStackStartupProbe() *corev1.Probe {
+	return &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path:   LightspeedStackReadinessPath,
+				Port:   intstr.FromInt32(OpenStackLightspeedAppServerContainerPort),
+				Scheme: corev1.URISchemeHTTPS,
+			},
+		},
+		PeriodSeconds:    LightspeedStackProbePeriodSeconds,
+		TimeoutSeconds:   LightspeedStackProbeTimeoutSeconds,
+		FailureThreshold: LightspeedStackStartupProbeFailureThreshold,
+	}
+}
+
 // buildLightspeedStackLivenessProbe returns the liveness probe for the lightspeed-stack container.
 func buildLightspeedStackLivenessProbe() *corev1.Probe {
 	return &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
-			TCPSocket: &corev1.TCPSocketAction{
-				Port: intstr.FromInt32(OpenStackLightspeedAppServerContainerPort),
+			HTTPGet: &corev1.HTTPGetAction{
+				Path:   LightspeedStackLivenessPath,
+				Port:   intstr.FromInt32(OpenStackLightspeedAppServerContainerPort),
+				Scheme: corev1.URISchemeHTTPS,
 			},
 		},
-		InitialDelaySeconds: 30,
-		PeriodSeconds:       10,
-		TimeoutSeconds:      5,
-		FailureThreshold:    3,
+		PeriodSeconds:    LightspeedStackProbePeriodSeconds,
+		TimeoutSeconds:   LightspeedStackProbeTimeoutSeconds,
+		FailureThreshold: LightspeedStackProbeFailureThreshold,
 	}
 }
 
@@ -670,14 +688,15 @@ func buildLightspeedStackLivenessProbe() *corev1.Probe {
 func buildLightspeedStackReadinessProbe() *corev1.Probe {
 	return &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
-			TCPSocket: &corev1.TCPSocketAction{
-				Port: intstr.FromInt32(OpenStackLightspeedAppServerContainerPort),
+			HTTPGet: &corev1.HTTPGetAction{
+				Path:   LightspeedStackReadinessPath,
+				Port:   intstr.FromInt32(OpenStackLightspeedAppServerContainerPort),
+				Scheme: corev1.URISchemeHTTPS,
 			},
 		},
-		InitialDelaySeconds: 30,
-		PeriodSeconds:       10,
-		TimeoutSeconds:      5,
-		FailureThreshold:    3,
+		PeriodSeconds:    LightspeedStackProbePeriodSeconds,
+		TimeoutSeconds:   LightspeedStackProbeTimeoutSeconds,
+		FailureThreshold: LightspeedStackProbeFailureThreshold,
 	}
 }
 

--- a/test/kuttl/common/expected-configs/lightspeed-stack-okp.yaml
+++ b/test/kuttl/common/expected-configs/lightspeed-stack-okp.yaml
@@ -1,5 +1,6 @@
 authentication:
   module: k8s
+  skip_for_health_probes: true
 byok_rag:
 - rag_id: vs_UUID
   vector_db_id: vs_UUID

--- a/test/kuttl/common/expected-configs/lightspeed-stack-update.yaml
+++ b/test/kuttl/common/expected-configs/lightspeed-stack-update.yaml
@@ -1,5 +1,6 @@
 authentication:
   module: k8s
+  skip_for_health_probes: true
 byok_rag:
 - rag_id: vs_UUID
   vector_db_id: vs_UUID

--- a/test/kuttl/common/expected-configs/lightspeed-stack.yaml
+++ b/test/kuttl/common/expected-configs/lightspeed-stack.yaml
@@ -1,5 +1,6 @@
 authentication:
   module: k8s
+  skip_for_health_probes: true
 byok_rag:
 - rag_id: vs_UUID
   vector_db_id: vs_UUID


### PR DESCRIPTION
Replace the TCP socket readiness/liveness probe with a proper HTTP GET on /readiness and /liveness.

We also need to set the authentication.skip_for_health_probes to true for the kubernetes probes to work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added health-check settings for the Lightspeed stack container, including liveness, readiness, and startup probe paths and timing values.
  * Authentication handling now includes support for Kubernetes-based config and skips health probes during authentication checks.

* **Bug Fixes**
  * Updated container health checks to use HTTPS endpoint checks instead of TCP socket checks, improving probe accuracy and reliability.
  * Improved startup probe behavior for the service container to better handle application startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->