### PR TITLE
Use pg_isready health checks for PostgreSQL

### DIFF
--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -67,6 +67,20 @@ const (
 	PostgresVarRunVolumeMountPath                = "/var/run/postgresql"
 	TmpVolumeName                                = "tmp-writable-volume"
 	TmpVolumeMountPath                           = "/tmp"
+	// Health probe settings for the PostgreSQL container.
+	// Startup probe allows up to 300s for initialization (e.g. WAL recovery).
+	// Liveness uses a longer period/timeout to avoid killing a busy-but-healthy instance.
+	// Readiness uses a shorter period to quickly pull the pod from traffic when not accepting connections.
+	PostgresStartupProbeInitialDelaySeconds = int32(5)
+	PostgresStartupProbePeriodSeconds       = int32(10)
+	PostgresStartupProbeTimeoutSeconds      = int32(5)
+	PostgresStartupProbeFailureThreshold    = int32(30)
+	PostgresLivenessProbePeriodSeconds      = int32(30)
+	PostgresLivenessProbeTimeoutSeconds     = int32(10)
+	PostgresLivenessProbeFailureThreshold   = int32(3)
+	PostgresReadinessProbePeriodSeconds     = int32(10)
+	PostgresReadinessProbeTimeoutSeconds    = int32(5)
+	PostgresReadinessProbeFailureThreshold  = int32(3)
 
 	// LCore specific
 	LlamaStackContainerPort  = int32(8321)

--- a/internal/controller/postgres_deployment.go
+++ b/internal/controller/postgres_deployment.go
@@ -142,7 +142,10 @@ func buildPostgresPodTemplateSpec() corev1.PodTemplateSpec {
 						AllowPrivilegeEscalation: &[]bool{false}[0],
 						ReadOnlyRootFilesystem:   &[]bool{true}[0],
 					},
-					VolumeMounts: volumeMounts,
+					StartupProbe:   buildPostgresProbe(PostgresStartupProbePeriodSeconds, PostgresStartupProbeTimeoutSeconds, PostgresStartupProbeFailureThreshold, PostgresStartupProbeInitialDelaySeconds),
+					LivenessProbe:  buildPostgresProbe(PostgresLivenessProbePeriodSeconds, PostgresLivenessProbeTimeoutSeconds, PostgresLivenessProbeFailureThreshold, 0),
+					ReadinessProbe: buildPostgresProbe(PostgresReadinessProbePeriodSeconds, PostgresReadinessProbeTimeoutSeconds, PostgresReadinessProbeFailureThreshold, 0),
+					VolumeMounts:   volumeMounts,
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							corev1.ResourceCPU:    resource.MustParse("30m"),
@@ -193,5 +196,19 @@ func buildPostgresPodTemplateSpec() corev1.PodTemplateSpec {
 			},
 			Volumes: volumes,
 		},
+	}
+}
+
+func buildPostgresProbe(period, timeout, failure, initialDelay int32) *corev1.Probe {
+	return &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			Exec: &corev1.ExecAction{
+				Command: []string{"pg_isready", "-U", PostgresDefaultUser, "-d", PostgresDefaultDbName},
+			},
+		},
+		InitialDelaySeconds: initialDelay,
+		PeriodSeconds:       period,
+		TimeoutSeconds:      timeout,
+		FailureThreshold:    failure,
 	}
 }


### PR DESCRIPTION
Add startup, liveness, and readiness probes to the lightspeed-postgres-server container using pg_isready.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PostgreSQL container health checks for startup, liveness, and readiness.
  * Health probes now verify the database with `pg_isready`, improving pod startup and availability detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->