### PR TITLE
Add migration notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+ > **This repository has been migrated to [openstack-k8s-operators/lightspeed-operator](https://github.com/openstack-k8s-operators/lightspeed-operator). Please open all new issues and pull requests there. This repository is archived and no longer maintained.**
+
 # OpenStack Lightspeed Operator
 
 OpenStack Lightspeed Operator is a generative AI-based virtual assistant for


### PR DESCRIPTION
## Summary
- Added migration notice to README pointing to the new repository at [openstack-k8s-operators/lightspeed-operator](https://github.com/openstack-k8s-operators/lightspeed-operator)
- This repository should be archived after this PR is merged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an archive notice at the top of the README.
  * Pointed contributors to the new repository for future issues and pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->